### PR TITLE
feat(recallaxis): stamp X-Cass-Gc-Session-Id from the transcript sidecar

### DIFF
--- a/internal/recallaxis/forward.go
+++ b/internal/recallaxis/forward.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -17,6 +18,50 @@ type readResult struct {
 	data    []byte
 	size    int64 // stat size at read time
 	mtimeNS int64
+	// gcSessionID is the gc session id read from the transcript's sidecar
+	// (<path>.gcmeta), or "" when there is none. Populated just before upload.
+	gcSessionID string
+}
+
+// sidecarSuffix matches the producer (gascity internal/transcriptmeta.Suffix):
+// the session-id sidecar lives at "<transcript-path>.gcmeta".
+const sidecarSuffix = ".gcmeta"
+
+// maxSidecarBytes caps the sidecar read. A sidecar holds one opaque session id
+// (far under this); the cap bounds memory the same way the transcript read does.
+const maxSidecarBytes = 256
+
+// readGCSessionID returns the gc session id recorded in the sidecar next to
+// path, or "" when the sidecar is absent, not a regular file, oversized, empty,
+// or not a safe HTTP header value. It reuses the hardened transcript read
+// primitive (readCappedOS: O_NOFOLLOW + O_NONBLOCK + fstat regular-file + size
+// cap, no TOCTOU), so a planted symlink, FIFO, device, or giant file at
+// "<path>.gcmeta" can neither exfiltrate another file's contents into the
+// egress header, wedge the single-goroutine scan loop, nor exhaust memory.
+// Best-effort: any problem yields "" and never blocks the transcript upload.
+func readGCSessionID(path string) string {
+	rr, ok := readCappedOS(path+sidecarSuffix, maxSidecarBytes)
+	if !ok {
+		return ""
+	}
+	id := strings.TrimSpace(string(rr.data))
+	if id == "" || !isSafeHeaderValue(id) {
+		return ""
+	}
+	return id
+}
+
+// isSafeHeaderValue reports whether s is safe to send as an HTTP header value:
+// printable ASCII with no spaces or control bytes, so a malformed sidecar can
+// never inject a header or smuggle CR/LF. gc session ids are opaque
+// alphanumeric+dash tokens, well within this.
+func isSafeHeaderValue(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x21 || s[i] > 0x7e {
+			return false
+		}
+	}
+	return true
 }
 
 // readCapped opens path (no symlink follow), fstats it, and reads up to MaxBytes. It
@@ -54,6 +99,11 @@ func postSnapshot(ctx context.Context, client *http.Client, cfg Config, token st
 	h.Set("X-Cass-Sha256", s2)
 	h.Set("X-Cass-Source-Mtime-Ns", strconv.FormatInt(rr.mtimeNS, 10))
 	h.Set("X-Cass-Source-Size", strconv.FormatInt(rr.size, 10))
+	if rr.gcSessionID != "" {
+		// Lets the server tie this transcript to a gc session (and thus the
+		// event-stream run timeline). Absent when the producer wrote no sidecar.
+		h.Set("X-Cass-Gc-Session-Id", rr.gcSessionID)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -177,6 +227,11 @@ func (r *Runner) ScanOnce(ctx context.Context, st *State) ScanStats {
 			st.Put(c.path, prior)
 			continue
 		}
+
+		// Best-effort: attach the gc session id from the sidecar (if any). Read
+		// only when we are actually uploading, so it costs nothing on the
+		// unchanged-content fast path above.
+		rr.gcSessionID = readGCSessionID(c.path)
 
 		status, perr := r.post(ctx, r.client, r.cfg, token, c, rr)
 		if perr != nil {

--- a/internal/recallaxis/sidecar_security_test.go
+++ b/internal/recallaxis/sidecar_security_test.go
@@ -1,0 +1,92 @@
+//go:build !windows
+
+package recallaxis
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestReadGCSessionID_RejectsSymlink is the credential-exfil regression: a
+// planted symlinked sidecar pointing at a single-line secret must NOT be read
+// (the hardened open uses O_NOFOLLOW). The secret shape passes isSafeHeaderValue,
+// so only the refusal-to-follow keeps it off the wire.
+func TestReadGCSessionID_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret")
+	if err := os.WriteFile(secret, []byte("sk-live-DEADBEEF"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(dir, "t.jsonl")
+	if err := os.Symlink(secret, transcript+sidecarSuffix); err != nil {
+		t.Fatal(err)
+	}
+	if got := readGCSessionID(transcript); got != "" {
+		t.Fatalf("symlinked sidecar leaked %q, want \"\"", got)
+	}
+}
+
+// TestReadGCSessionID_RejectsFIFO: a writerless FIFO sidecar must return ""
+// immediately (O_NONBLOCK + regular-file check), never blocking the single
+// scan goroutine.
+func TestReadGCSessionID_RejectsFIFO(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "t.jsonl")
+	if err := syscall.Mkfifo(transcript+sidecarSuffix, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	done := make(chan string, 1)
+	go func() { done <- readGCSessionID(transcript) }()
+	select {
+	case got := <-done:
+		if got != "" {
+			t.Fatalf("FIFO sidecar => %q, want \"\"", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("readGCSessionID blocked on a writerless FIFO sidecar")
+	}
+}
+
+// TestReadGCSessionID_RejectsOversizedRegular: a >cap regular sidecar is dropped
+// by the size cap (never fully read into memory).
+func TestReadGCSessionID_RejectsOversizedRegular(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "t.jsonl")
+	big := make([]byte, maxSidecarBytes+50)
+	for i := range big {
+		big[i] = 'a'
+	}
+	if err := os.WriteFile(transcript+sidecarSuffix, big, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readGCSessionID(transcript); got != "" {
+		t.Fatalf("oversized sidecar => %q, want \"\"", got)
+	}
+}
+
+// TestUploadDoesNotExfilSymlinkedSidecar is the end-to-end exfil regression: a
+// symlinked sidecar must not place a secret on the wire.
+func TestUploadDoesNotExfilSymlinkedSidecar(t *testing.T) {
+	root := setupSingleTranscriptRoot(t)
+	transcript := filepath.Join(root, "proj", singleTranscriptName)
+	secret := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(secret, []byte("sk-live-DEADBEEF"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, transcript+sidecarSuffix); err != nil {
+		t.Fatal(err)
+	}
+
+	var got http.Header
+	runWithServer(t, root, func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(201)
+	})
+	if _, present := got["X-Cass-Gc-Session-Id"]; present {
+		t.Errorf("symlinked sidecar leaked header: %q", got.Get("X-Cass-Gc-Session-Id"))
+	}
+}

--- a/internal/recallaxis/sidecar_test.go
+++ b/internal/recallaxis/sidecar_test.go
@@ -1,0 +1,103 @@
+package recallaxis
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const singleTranscriptName = "01234567-89ab-cdef-0123-456789abcdef.jsonl"
+
+// TestUploadStampsGCSessionIDFromSidecar: when a <transcript>.gcmeta sidecar
+// exists, the forwarder reads it and stamps X-Cass-Gc-Session-Id — and the
+// sidecar itself is NOT uploaded (it is not a transcript shape).
+func TestUploadStampsGCSessionIDFromSidecar(t *testing.T) {
+	root := setupSingleTranscriptRoot(t)
+	transcript := filepath.Join(root, "proj", singleTranscriptName)
+	if err := os.WriteFile(transcript+sidecarSuffix, []byte("gc-session-abc\n"), 0o600); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	var got http.Header
+	stats, _, hits := runWithServer(t, root, func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(201)
+	})
+	if *hits != 1 {
+		t.Fatalf("server hit %d times, want 1 (the sidecar must not be uploaded)", *hits)
+	}
+	if stats.Sent != 1 {
+		t.Fatalf("stats=%+v, want Sent=1", stats)
+	}
+	if v := got.Get("X-Cass-Gc-Session-Id"); v != "gc-session-abc" {
+		t.Errorf("X-Cass-Gc-Session-Id = %q, want %q", v, "gc-session-abc")
+	}
+}
+
+// TestUploadOmitsGCSessionIDWithoutSidecar: no sidecar => header absent (not
+// empty-string present), so the server can tell "no correlation" cleanly.
+func TestUploadOmitsGCSessionIDWithoutSidecar(t *testing.T) {
+	root := setupSingleTranscriptRoot(t)
+
+	var got http.Header
+	runWithServer(t, root, func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(201)
+	})
+	if _, present := got["X-Cass-Gc-Session-Id"]; present {
+		t.Errorf("X-Cass-Gc-Session-Id present without a sidecar: %q", got.Get("X-Cass-Gc-Session-Id"))
+	}
+}
+
+func TestReadGCSessionID(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "t.jsonl")
+	set := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(transcript+sidecarSuffix, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := readGCSessionID(transcript); got != "" {
+		t.Errorf("no sidecar => %q, want \"\"", got)
+	}
+
+	set("gc-session-1\n")
+	if got := readGCSessionID(transcript); got != "gc-session-1" {
+		t.Errorf("got %q, want gc-session-1", got)
+	}
+
+	// Header-injection attempt: CR/LF and control bytes must be rejected outright.
+	set("gc-1\r\nX-Evil: pwned")
+	if got := readGCSessionID(transcript); got != "" {
+		t.Errorf("control chars must be rejected, got %q", got)
+	}
+
+	// Whitespace-only / empty.
+	set("   \n")
+	if got := readGCSessionID(transcript); got != "" {
+		t.Errorf("blank sidecar => %q, want \"\"", got)
+	}
+
+	// Oversized.
+	set(strings.Repeat("a", 300))
+	if got := readGCSessionID(transcript); got != "" {
+		t.Errorf("oversized sidecar must be rejected, got len %d", len(got))
+	}
+}
+
+func TestIsSafeHeaderValue(t *testing.T) {
+	for _, ok := range []string{"gc-session-1", "abc123", "GC_Session.42", "a"} {
+		if !isSafeHeaderValue(ok) {
+			t.Errorf("%q should be safe", ok)
+		}
+	}
+	for _, bad := range []string{"with space", "tab\tx", "nl\n", "cr\r", "ctrl\x00", "unicodé"} {
+		if isSafeHeaderValue(bad) {
+			t.Errorf("%q should be rejected", bad)
+		}
+	}
+}


### PR DESCRIPTION
Part of the **run-timeline transcript join** (session-level spine). Before uploading a transcript, the forwarder reads the producer's `<path>.gcmeta` sidecar (the gc session id) and stamps it as `X-Cass-Gc-Session-Id`, so recall can tie a transcript to a gc session — and thus the event-stream run timeline.

**Security (red-team HIGH, fixed):** the sidecar is read through the package's hardened primitive (`readCappedOS`: `O_NOFOLLOW` + `O_NONBLOCK` + fstat regular-file + 256B cap, no TOCTOU), so a planted symlink/FIFO/device/giant file at the sidecar path cannot exfiltrate another file's contents into the egress header, wedge the scan goroutine, or exhaust memory. The header value is validated printable-ASCII/no-space (no header injection). Any problem → no header, never blocks the upload. `.gcmeta` is never itself uploaded (only `.jsonl`/`.json`).

Regression tests: symlink-exfil (unit + e2e), writerless-FIFO non-block, oversize cap, header stamped/omitted, validation.

Companion PRs: gascity producer (writes the sidecar) + cass-service (stores gc_session_id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gascity/codesmith/gasworks/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784856178&installation_id=141368595&pr_number=38&repository=gascity%2Fgasworks&return_to=https%3A%2F%2Fgithub.com%2Fgascity%2Fgasworks%2Fpull%2F38&signature=c622f5a48e48c0e427194ca07b469096b74a704de1ad9619de5ec0f7f7cec940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->