### PR TITLE
fix(getToken): keep the friendly unentitled-product check when --scope is given (G11)

### DIFF
--- a/cmd/gasworks/cli_test.go
+++ b/cmd/gasworks/cli_test.go
@@ -279,6 +279,26 @@ func TestGetTokenUnentitledProductIsClearError(t *testing.T) {
 	}
 }
 
+// G11: --scope must NOT bypass the friendly unentitled-product check into a raw STS
+// 400 invalid_target. An explicit scope still requires the product to be mintable.
+func TestGetTokenUnentitledProductWithScopeIsClearError(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	_, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "crucible", "--scope", "crucible:exec"})
+	})
+	if code == 0 {
+		t.Fatal("want non-zero exit for an unentitled product even with --scope")
+	}
+	if !strings.Contains(errOut, "no mintable 'crucible' scope") {
+		t.Fatalf("stderr = %q, want the clear unentitled-product error", errOut)
+	}
+	if got := srv.reqs("/sts/v0/token"); len(got) != 0 {
+		t.Fatalf("must NOT reach the STS token endpoint for an unentitled product, got %d mints", len(got))
+	}
+}
+
 func TestGetTokenRequiresLogin(t *testing.T) {
 	srv := newStub(t)
 	seed(t, srv, map[string]any{}) // no refresh token / id token

--- a/cmd/gasworks/gettoken.go
+++ b/cmd/gasworks/gettoken.go
@@ -65,14 +65,16 @@ func cmdGetToken(cfg config.Config, argv []string) error {
 		return die("you are not a member of org %s", org)
 	}
 
+	// The product must be a mintable product for this org regardless of --scope, so an
+	// explicit scope can't bypass this into a confusing raw STS 400 invalid_target.
+	prod, ok := orgCtx.Products[product]
+	if !ok || len(prod.Scopes) == 0 {
+		return die("no mintable '%s' scope for org %s (entitled products: %s)",
+			product, orgCtx.Slug, productNames(orgCtx.Products))
+	}
 	scope := *scopeFlag
 	if scope == "" {
-		prod, ok := orgCtx.Products[product]
-		if !ok || len(prod.Scopes) == 0 {
-			return die("no mintable '%s' scope for org %s (entitled products: %s)",
-				product, orgCtx.Slug, productNames(orgCtx.Products))
-		}
-		scope = strings.Join(prod.Scopes, " ")
+		scope = strings.Join(prod.Scopes, " ") // default to the discovered scopes
 	}
 
 	cacheKey := org + "|" + product + "|" + scope


### PR DESCRIPTION
Hoists the product-mintability check in `getToken` so it runs **regardless of `--scope`**. Previously `getToken <unentitled> --scope x` bypassed the check and surfaced a raw `400 invalid_target` instead of the friendly "no mintable '<product>' scope" message. `--scope` still works as a scope override for mintable products. New test asserts the friendly error + never reaching /sts/v0/token; mutation-verified; full suite green. (audit gap G11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gascity/codesmith/gasworks/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784867802&installation_id=141368595&pr_number=40&repository=gascity%2Fgasworks&return_to=https%3A%2F%2Fgithub.com%2Fgascity%2Fgasworks%2Fpull%2F40&signature=3f33ab575913b04acf298d66570e8b8e56b9fd38b1f19cb2c63d6222a5395a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->