### PR TITLE
feat(usage): add the usage forwarder axis (tail .gc/usage.jsonl to usage-ingest)

### DIFF
--- a/cmd/gasworks-forwarder/main.go
+++ b/cmd/gasworks-forwarder/main.go
@@ -1,7 +1,7 @@
-// Command gasworks-forwarder ships coding-agent transcripts (recall) and redacted
-// city events (events) to their hosted ingest endpoints. Each AXIS — recall, events —
-// has its OWN config and OWN bearer credential: a recall raw-content token is never
-// shared with the events axis, and vice versa (axis isolation). The dispatch below
+// Command gasworks-forwarder ships coding-agent transcripts (recall), redacted city
+// events (events), and usage facts (usage) to their hosted ingest endpoints. Each
+// AXIS — recall, events, usage — has its OWN config and OWN bearer credential: one
+// axis's token is never shared with another (axis isolation). The dispatch below
 // builds each axis independently so a misconfigured or compromised axis cannot leak
 // its peer's credential.
 //
@@ -9,6 +9,7 @@
 //
 //	recall   run the recall transcript forwarder (RECALL_FORWARDER_* env)
 //	events   run the events forwarder (GASWORKS_EVENTS_* env)
+//	usage    run the usage forwarder, tailing .gc/usage.jsonl (GASWORKS_USAGE_* env)
 //	all      run every axis as independently-restartable goroutines (own config + bearer)
 //
 // Add --once to run a single scan pass and exit (recall only); default is the daemon
@@ -30,6 +31,7 @@ import (
 
 	"github.com/gascity/gasworks/internal/eventsaxis"
 	"github.com/gascity/gasworks/internal/recallaxis"
+	"github.com/gascity/gasworks/internal/usageaxis"
 	"github.com/gascity/gasworks/internal/version"
 )
 
@@ -51,6 +53,8 @@ func run(argv []string) int {
 		return runRecall(ctx, rest)
 	case "events":
 		return runEvents(ctx, rest)
+	case "usage":
+		return runUsage(ctx, rest)
 	case "all":
 		return runAll(ctx, rest)
 	case "version", "--version":
@@ -171,6 +175,52 @@ func runEvents(ctx context.Context, args []string) int {
 	return 0
 }
 
+// runUsage wires the usage axis from GASWORKS_USAGE_* env. It builds the axis's OWN
+// config + bearer and tails the gc usage ledger (.gc/usage.jsonl), forwarding model
+// facts to usage-ingest. With --once it drains to EOF and exits; otherwise it runs
+// the daemon loop.
+func runUsage(ctx context.Context, args []string) int {
+	once := false
+	for _, a := range args {
+		switch a {
+		case "--once":
+			once = true
+		case "-h", "--help":
+			eprintln("usage: gasworks-forwarder usage [--once]")
+			return 0
+		default:
+			eprintf("gasworks-forwarder usage: unknown flag %q", a)
+			return 2
+		}
+	}
+
+	cfg, warn := usageaxis.ConfigFromEnv()
+	if warn != "" {
+		eprintf("gasworks-forwarder: warning: %s", warn)
+	}
+
+	// Validate the destination scheme up front so a plain-http misconfig fails loudly
+	// instead of silently idling — but only when a URL was actually provided.
+	if cfg.URL != "" && !usageaxis.URLOK(cfg.URL, cfg.AllowHTTP) {
+		eprintln("gasworks-forwarder usage: GASWORKS_USAGE_INGEST_URL must be https:// (or localhost http with GASWORKS_USAGE_ALLOW_HTTP=1)")
+		return 1
+	}
+	if !cfg.Enabled() {
+		eprintln("gasworks-forwarder usage: idle — GASWORKS_USAGE_INGEST_URL / _SOURCE_ID / _LEDGER / token not all set (opt in to enable)")
+	}
+
+	runner := usageaxis.NewRunner(cfg, logf)
+	run := runner.Run
+	if once {
+		run = runner.RunOnce
+	}
+	if err := run(ctx); err != nil {
+		eprintf("gasworks-forwarder usage: %v", err)
+		return 1
+	}
+	return 0
+}
+
 // runAll runs recall AND events concurrently, each in its own goroutine with a
 // per-axis recover() + backoff supervisor. This reinstates in-process the isolation
 // the two axes have as separate systemd units: one axis panicking, or its source
@@ -209,7 +259,7 @@ func runAll(ctx context.Context, args []string) int {
 		}
 	)
 
-	wg.Add(2)
+	wg.Add(3)
 	go func() {
 		defer wg.Done()
 		recordCode(superviseAxis(ctx, "recall", func() int { return runRecall(ctx, nil) }))
@@ -217,6 +267,10 @@ func runAll(ctx context.Context, args []string) int {
 	go func() {
 		defer wg.Done()
 		recordCode(superviseAxis(ctx, "events", func() int { return runEvents(ctx, nil) }))
+	}()
+	go func() {
+		defer wg.Done()
+		recordCode(superviseAxis(ctx, "usage", func() int { return runUsage(ctx, nil) }))
 	}()
 	wg.Wait()
 	return worst
@@ -286,15 +340,16 @@ func eprintf(format string, args ...any) { fmt.Fprintf(os.Stderr, format+"\n", a
 func eprintln(s string)                  { fmt.Fprintln(os.Stderr, s) }
 
 func usage() {
-	const u = `gasworks-forwarder: ship coding-agent transcripts (recall) and redacted city events to hosted ingest.
+	const u = `gasworks-forwarder: ship coding-agent transcripts (recall), redacted city events (events), and usage facts (usage) to hosted ingest.
 
 Usage:
   gasworks-forwarder recall [--once]   run the recall transcript forwarder
   gasworks-forwarder events            run the events forwarder (tails the supervisor SSE)
+  gasworks-forwarder usage  [--once]   run the usage forwarder (tails .gc/usage.jsonl)
   gasworks-forwarder all               run every axis (own goroutine + recover + backoff)
 
-Each axis has its OWN config + bearer credential (axis isolation): a recall raw-content
-token is never usable by the events axis, and vice versa. The recall axis is configured
-via RECALL_FORWARDER_* env; the events axis via GASWORKS_EVENTS_* env (see the package docs).`
+Each axis has its OWN config + bearer credential (axis isolation): one axis's token is
+never usable by another. recall is configured via RECALL_FORWARDER_* env; events via
+GASWORKS_EVENTS_* env; usage via GASWORKS_USAGE_* env (see the package docs).`
 	fmt.Fprintln(os.Stderr, u)
 }

--- a/internal/usageaxis/fileid_other.go
+++ b/internal/usageaxis/fileid_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package usageaxis
+
+import "os"
+
+// fileID has no portable inode on non-unix platforms; rotation detection there falls
+// back to the size<offset truncation check.
+func fileID(os.FileInfo) (uint64, bool) { return 0, false }

--- a/internal/usageaxis/fileid_unix.go
+++ b/internal/usageaxis/fileid_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package usageaxis
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileID returns the ledger's inode as a stable filesystem identity. A new inode
+// (rename-and-recreate, or a fresh file at the same path) means the ledger rotated,
+// which the byte-offset check alone cannot see. Returns ok=false if the platform's
+// FileInfo carries no inode.
+func fileID(fi os.FileInfo) (uint64, bool) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return uint64(st.Ino), true
+	}
+	return 0, false
+}

--- a/internal/usageaxis/runner.go
+++ b/internal/usageaxis/runner.go
@@ -1,0 +1,210 @@
+package usageaxis
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Logf is an injectable structured logger; it MUST NOT be called with the token
+// value. The axis upholds that contract.
+type Logf func(format string, args ...any)
+
+const postTimeout = 30 * time.Second
+
+// postResult is the outcome of one batch POST.
+type postResult struct {
+	advance   bool // 2xx: commit the cursor
+	retryable bool // back off and retry (the cursor is NOT advanced)
+}
+
+// Runner owns the usage axis: it tails the ledger, batches, and POSTs to
+// usage-ingest, persisting the per-source resume cursor only on a confirmed POST.
+// Construct it with NewRunner.
+type Runner struct {
+	cfg        Config
+	log        Logf
+	postClient *http.Client
+
+	// seams for tests
+	tail func(path string, cur Cursor, max int) ([]Fact, Cursor, bool, error)
+	post func(ctx context.Context, b Batch) postResult
+}
+
+// NewRunner constructs a Runner. The HTTP client is built ONLY when the axis is
+// Enabled() — a disabled axis never constructs a client or dials. log may be nil.
+func NewRunner(cfg Config, log Logf) *Runner {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	r := &Runner{cfg: cfg, log: log, tail: Tail}
+	if cfg.Enabled() {
+		r.postClient = newPostClient()
+	}
+	r.post = r.httpPost
+	return r
+}
+
+// newPostClient builds the bounded-timeout POST client: refuses ALL redirects so the
+// bearer can't bounce to another host, pins a TLS 1.2 floor (verification stays on),
+// and carries a timeout so a hung ingest endpoint can't wedge the loop.
+func newPostClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   postTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// Run drains the ledger to usage-ingest on each BatchInterval tick until ctx is
+// cancelled, persisting the resume cursor after every confirmed POST. A disabled
+// axis returns immediately (it never dials). With once=true it does a single drain
+// pass and returns (cron / test mode).
+func (r *Runner) Run(ctx context.Context) error { return r.run(ctx, false) }
+
+// RunOnce does a single drain pass (catch up to EOF) and returns.
+func (r *Runner) RunOnce(ctx context.Context) error { return r.run(ctx, true) }
+
+func (r *Runner) run(ctx context.Context, once bool) error {
+	if !r.cfg.Enabled() {
+		r.log("usage: idle — GASWORKS_USAGE_INGEST_URL / _SOURCE_ID / _LEDGER / token not all set (opt in to enable)")
+		return nil
+	}
+	if !URLOK(r.cfg.URL, r.cfg.AllowHTTP) {
+		return fmt.Errorf("usage: GASWORKS_USAGE_INGEST_URL must be https:// (or localhost http with GASWORKS_USAGE_ALLOW_HTTP=1)")
+	}
+
+	st, _ := LoadState(r.cfg.StatePath)
+	cur, ok := st.Get(r.cfg.SourceID)
+	if !ok || cur.NextSeq == 0 {
+		cur = Cursor{Offset: cur.Offset, NextSeq: 1} // 1-based seq for a fresh source
+	}
+
+	r.log("usage: start source=%s ledger=%s interval=%s", r.cfg.SourceID, r.cfg.Ledger, r.cfg.BatchInterval)
+
+	drain := func() {
+		cur = r.drain(ctx, cur, st)
+	}
+
+	drain() // catch up immediately on start
+	if once {
+		return nil
+	}
+
+	t := time.NewTicker(r.cfg.BatchInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.log("usage: stopped")
+			return nil
+		case <-t.C:
+			drain()
+		}
+	}
+}
+
+// drain tails+POSTs repeated batches until caught up (no new facts) or a POST asks to
+// back off, persisting the cursor after each confirmed batch. It returns the latest
+// committed cursor. Bounded by maxBatchesPerDrain so one tick can't hog forever.
+const maxBatchesPerDrain = 50
+
+func (r *Runner) drain(ctx context.Context, cur Cursor, st *State) Cursor {
+	for i := 0; i < maxBatchesPerDrain; i++ {
+		if ctx.Err() != nil {
+			return cur
+		}
+		facts, next, rotated, err := r.tail(r.cfg.Ledger, cur, r.cfg.BatchMax)
+		if err != nil {
+			r.log("usage: tail error: %v", err)
+			return cur
+		}
+		if rotated {
+			r.log("usage: ledger rotated/truncated; resuming from the top (seq stays monotonic)")
+		}
+		if len(facts) == 0 {
+			// No facts, but the offset may have advanced past skipped lines — commit it
+			// so we don't re-scan them forever.
+			if next.Offset != cur.Offset {
+				r.commit(st, next)
+				cur = next
+			}
+			return cur
+		}
+		res := r.post(ctx, Batch{SourceID: r.cfg.SourceID, SchemaVersion: SchemaVersion, Facts: facts})
+		if !res.advance {
+			if res.retryable {
+				r.log("usage: POST not accepted (%d facts held; cursor unchanged, will retry)", len(facts))
+			}
+			return cur // do NOT advance: the same facts/seqs re-POST next time (idempotent)
+		}
+		r.commit(st, next)
+		cur = next
+	}
+	return cur
+}
+
+// commit persists the cursor for this source, logging (never failing) on a write
+// error so a transient disk problem never crashes the axis.
+func (r *Runner) commit(st *State, cur Cursor) {
+	st.Put(r.cfg.SourceID, cur)
+	if err := SaveState(r.cfg.StatePath, st); err != nil {
+		r.log("usage: cursor save failed: %v", err)
+	}
+}
+
+// httpPost POSTs one batch to usage-ingest with the usage bearer and classifies the
+// response into advance / retryable.
+func (r *Runner) httpPost(ctx context.Context, b Batch) postResult {
+	token, err := r.cfg.Token.Token()
+	if err != nil {
+		r.log("usage: token unavailable: %v", err)
+		return postResult{retryable: true}
+	}
+	if token == "" {
+		// An empty token (e.g. a not-yet-populated token file) would POST a bare
+		// "Authorization: Bearer " and 401. Idle this cycle instead and hold the
+		// cursor, so a later credential rotation enables the axis without data loss.
+		r.log("usage: token empty; idling this cycle (cursor held)")
+		return postResult{retryable: true}
+	}
+	body, err := json.Marshal(b)
+	if err != nil {
+		r.log("usage: batch marshal failed: %v", err) // not retryable, but should never happen
+		return postResult{}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return postResult{retryable: true}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := r.postClient.Do(req)
+	if err != nil {
+		r.log("usage: POST error: %v", err)
+		return postResult{retryable: true}
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	switch {
+	case resp.StatusCode/100 == 2:
+		return postResult{advance: true}
+	case resp.StatusCode == 429 || resp.StatusCode/100 == 5:
+		return postResult{retryable: true} // transient: hold the cursor, retry
+	default:
+		// 4xx (schema mismatch, auth, conflict): the batch won't succeed as-is. Hold
+		// the cursor and back off rather than skip — losing data is worse than a loud
+		// retry the operator can see and fix (e.g. a deploy-skew SchemaVersion).
+		r.log("usage: POST rejected %d (holding cursor; check token/schema/edge)", resp.StatusCode)
+		return postResult{retryable: true}
+	}
+}

--- a/internal/usageaxis/runner_test.go
+++ b/internal/usageaxis/runner_test.go
@@ -1,0 +1,116 @@
+package usageaxis
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gascity/gasworks/internal/saauth"
+)
+
+func testCfg(t *testing.T, ledger string) Config {
+	t.Helper()
+	return Config{
+		URL:           "https://usage-ingest.example/v0/usage-ingest",
+		SourceID:      "city-1",
+		Ledger:        ledger,
+		Token:         saauth.EnvProvider("tok"),
+		StatePath:     filepath.Join(t.TempDir(), "cursors.json"),
+		BatchMax:      100,
+		BatchInterval: time.Hour, // irrelevant: tests drive RunOnce
+	}
+}
+
+// fakePoster records the batches it received and returns a scripted result.
+type fakePoster struct {
+	mu      sync.Mutex
+	batches []Batch
+	result  postResult
+}
+
+func (f *fakePoster) post(_ context.Context, b Batch) postResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.batches = append(f.batches, b)
+	return f.result
+}
+
+func TestRunOnceForwardsAndCommitsCursor(t *testing.T) {
+	ledger := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+
+	if err := r.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fp.batches) != 1 || len(fp.batches[0].Facts) != 2 {
+		t.Fatalf("want one batch of 2 facts, got %+v", fp.batches)
+	}
+	if fp.batches[0].SourceID != "city-1" || fp.batches[0].SchemaVersion != SchemaVersion {
+		t.Fatalf("batch envelope wrong: %+v", fp.batches[0])
+	}
+	if fp.batches[0].Facts[0].Seq != 1 || fp.batches[0].Facts[1].Seq != 2 {
+		t.Fatalf("seq must be 1-based monotonic: %+v", fp.batches[0].Facts)
+	}
+	// Cursor persisted at EOF / NextSeq 3.
+	st, _ := LoadState(cfg.StatePath)
+	cur, ok := st.Get("city-1")
+	if !ok || cur.NextSeq != 3 {
+		t.Fatalf("cursor not committed: %+v ok=%v", cur, ok)
+	}
+}
+
+func TestRetryableHoldsCursorAndReplays(t *testing.T) {
+	ledger := writeLedger(t, factLine("r1", "m"))
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{retryable: true}} // POST fails: hold cursor
+	r.post = fp.post
+
+	_ = r.RunOnce(context.Background())
+	// Cursor must NOT be committed.
+	st, _ := LoadState(cfg.StatePath)
+	if _, ok := st.Get("city-1"); ok {
+		t.Fatal("a failed POST must not commit the cursor")
+	}
+	// Next pass succeeds -> the SAME fact (seq 1) is re-POSTed (idempotent replay).
+	fp.result = postResult{advance: true}
+	_ = r.RunOnce(context.Background())
+	last := fp.batches[len(fp.batches)-1]
+	if len(last.Facts) != 1 || last.Facts[0].Seq != 1 {
+		t.Fatalf("replay must re-send the same fact/seq: %+v", last.Facts)
+	}
+}
+
+func TestRunOnceNoFactsNoBatch(t *testing.T) {
+	ledger := writeLedger(t, "") // empty ledger
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+	_ = r.RunOnce(context.Background())
+	if len(fp.batches) != 0 {
+		t.Fatalf("empty ledger must POST nothing, got %d batches", len(fp.batches))
+	}
+}
+
+func TestDisabledAxisIsIdle(t *testing.T) {
+	cfg := testCfg(t, writeLedger(t, factLine("r1", "m")))
+	cfg.URL = "" // disable: egress gate closed
+	if cfg.Enabled() {
+		t.Fatal("cfg with no URL must be disabled")
+	}
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("disabled axis must return nil, got %v", err)
+	}
+	if len(fp.batches) != 0 {
+		t.Fatal("disabled axis must never POST")
+	}
+}

--- a/internal/usageaxis/source.go
+++ b/internal/usageaxis/source.go
@@ -1,0 +1,110 @@
+package usageaxis
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// maxScanBytes bounds one Tail read so a large backlog is chunked across scans
+// rather than read whole into memory. A single usage.jsonl line is a few hundred
+// bytes, so this holds thousands of facts per scan.
+const maxScanBytes = 8 << 20
+
+// Tail reads new COMPLETE lines from the ledger starting at cur.Offset, parses each
+// into a model Fact, assigns a per-source monotonic seq, and returns the facts to
+// forward plus the ADVANCED cursor. The returned cursor is a CANDIDATE — the caller
+// must commit (persist) it only AFTER a confirmed POST, so a crash before the POST
+// re-reads the same bytes and re-assigns the same seqs (idempotent under the
+// usage-ingest seq high-water-mark), losing nothing.
+//
+// Lines are only forwarded once they are complete (terminated by '\n'); a partial
+// trailing write is left for the next scan. Lines that don't parse, or whose kind is
+// not "model", are skipped — the offset still advances past them, but no seq is
+// consumed (so the seq->fact mapping is stable across replays). On truncation or
+// rotation (size < cur.Offset) the offset resets to 0 while NextSeq is preserved, so
+// the new ledger's facts get fresh seqs that never collide with the old ones.
+//
+// A missing ledger (gc hasn't written one yet) is not an error: it returns no facts
+// and the cursor unchanged (the axis idles until the file appears).
+func Tail(path string, cur Cursor, max int) (facts []Fact, next Cursor, rotated bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, cur, false, nil
+		}
+		return nil, cur, false, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, cur, false, err
+	}
+	size := st.Size()
+	id, haveID := fileID(st)
+
+	off := cur.Offset
+	// Rotation: the ledger's filesystem identity changed (rename-and-recreate — a new
+	// file the size check alone would miss because it may already be larger than the
+	// stale offset), OR it shrank below the offset (truncate / copytruncate). Either
+	// way re-read from the top and KEEP NextSeq so seqs stay globally monotonic.
+	if (haveID && cur.FileID != 0 && id != cur.FileID) || size < off {
+		off = 0
+		rotated = true
+	}
+	// The committed FileID always tracks the file we are reading now.
+	newID := cur.FileID
+	if haveID {
+		newID = id
+	}
+	if off >= size {
+		return nil, Cursor{Offset: off, NextSeq: cur.NextSeq, FileID: newID}, rotated, nil // nothing new
+	}
+
+	window := size - off
+	if window > maxScanBytes {
+		window = maxScanBytes
+	}
+	buf := make([]byte, window)
+	if _, err := f.ReadAt(buf, off); err != nil && err != io.EOF {
+		return nil, cur, rotated, err
+	}
+
+	seq := cur.NextSeq
+	if seq == 0 {
+		seq = 1 // seq is 1-based: usage-ingest rejects seq 0
+	}
+	consumed := 0
+	if max < 1 {
+		max = 1
+	}
+	for len(facts) < max {
+		nl := bytes.IndexByte(buf[consumed:], '\n')
+		if nl < 0 {
+			break // no more complete lines in this window
+		}
+		line := bytes.TrimSpace(buf[consumed : consumed+nl])
+		consumed += nl + 1 // step past the '\n'
+		if len(line) == 0 {
+			continue // blank line: skip, offset already advanced
+		}
+		var fct Fact
+		if json.Unmarshal(line, &fct) != nil || fct.Kind != KindModel {
+			continue // unparseable or non-model: drop, no seq consumed
+		}
+		fct.Seq = seq
+		seq++
+		facts = append(facts, fct)
+	}
+
+	// Stall guard: a single line longer than the whole window (no '\n' found while the
+	// window is the full maxScanBytes cap) would never make progress. Skip the
+	// oversized fragment by advancing past the window so the tail keeps moving.
+	if consumed == 0 && window == maxScanBytes {
+		consumed = len(buf)
+	}
+
+	return facts, Cursor{Offset: off + int64(consumed), NextSeq: seq, FileID: newID}, rotated, nil
+}

--- a/internal/usageaxis/source_test.go
+++ b/internal/usageaxis/source_test.go
@@ -1,0 +1,199 @@
+package usageaxis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeLedger writes raw bytes to a temp ledger and returns its path.
+func writeLedger(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "usage.jsonl")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func appendLedger(t *testing.T, path, content string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func factLine(runID, model string) string {
+	b, _ := json.Marshal(map[string]any{
+		"run_id": runID, "session_id": "s", "kind": "model", "model": model,
+		"provider": "anthropic", "input_tokens": 10, "output_tokens": 5,
+		"cost_usd_estimate": 0.001, "upstream_req_id": runID + "-r", "at": 1_700_000_000_000,
+	})
+	return string(b) + "\n"
+}
+
+func TestTailBasicAssignsMonotonicSeq(t *testing.T) {
+	p := writeLedger(t, factLine("run-1", "m1")+factLine("run-2", "m2"))
+	facts, next, rotated, err := Tail(p, Cursor{}, 100)
+	if err != nil || rotated {
+		t.Fatalf("err=%v rotated=%v", err, rotated)
+	}
+	if len(facts) != 2 {
+		t.Fatalf("want 2 facts, got %d", len(facts))
+	}
+	if facts[0].Seq != 1 || facts[1].Seq != 2 {
+		t.Fatalf("seq must be 1-based monotonic: %d, %d", facts[0].Seq, facts[1].Seq)
+	}
+	if facts[0].RunID != "run-1" || facts[1].Model != "m2" {
+		t.Fatalf("fields wrong: %+v", facts)
+	}
+	if next.NextSeq != 3 {
+		t.Fatalf("next seq = %d, want 3", next.NextSeq)
+	}
+	fi, _ := os.Stat(p)
+	if next.Offset != fi.Size() {
+		t.Fatalf("offset = %d, want EOF %d", next.Offset, fi.Size())
+	}
+}
+
+func TestTailLeavesPartialTrailingLine(t *testing.T) {
+	// One complete line + a partial (no trailing newline) line.
+	p := writeLedger(t, factLine("run-1", "m1")+`{"run_id":"run-2","kind":"mo`)
+	facts, next, _, _ := Tail(p, Cursor{}, 100)
+	if len(facts) != 1 || facts[0].RunID != "run-1" {
+		t.Fatalf("only the complete line should forward: %+v", facts)
+	}
+	// Offset is at the end of the complete line, NOT EOF (partial left for next scan).
+	if next.Offset != int64(len(factLine("run-1", "m1"))) {
+		t.Fatalf("offset must stop before the partial line, got %d", next.Offset)
+	}
+	// Completing the partial line on the next scan forwards it with the next seq.
+	appendLedger(t, p, `del","kind":"model","model":"m2","provider":"x","upstream_req_id":"r2","at":1700000000000,"session_id":"s"}`+"\n")
+	facts2, _, _, _ := Tail(p, next, 100)
+	if len(facts2) != 1 || facts2[0].Seq != 2 {
+		t.Fatalf("completed line should forward as seq 2: %+v", facts2)
+	}
+}
+
+func TestTailSkipsInvalidAndNonModelButAdvances(t *testing.T) {
+	content := factLine("run-1", "m1") +
+		"not json at all\n" +
+		`{"kind":"compute","wall_seconds":3,"run_id":"r","at":1}` + "\n" +
+		"\n" + // blank
+		factLine("run-2", "m2")
+	facts, next, _, _ := Tail(p_helper(t, content), Cursor{}, 100)
+	if len(facts) != 2 {
+		t.Fatalf("only the 2 model facts forward, got %d: %+v", len(facts), facts)
+	}
+	// seq is consumed only by forwarded facts: 1 and 2 (not skipped over).
+	if facts[0].Seq != 1 || facts[1].Seq != 2 {
+		t.Fatalf("seq must skip non-forwarded lines: %d, %d", facts[0].Seq, facts[1].Seq)
+	}
+	if next.NextSeq != 3 {
+		t.Fatalf("next seq = %d, want 3", next.NextSeq)
+	}
+}
+
+func TestTailRespectsMax(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m")+factLine("r3", "m"))
+	facts, next, _, _ := Tail(p, Cursor{}, 2)
+	if len(facts) != 2 {
+		t.Fatalf("max=2 must cap at 2 facts, got %d", len(facts))
+	}
+	// Next scan from the advanced cursor gets the 3rd with seq 3.
+	facts2, _, _, _ := Tail(p, next, 2)
+	if len(facts2) != 1 || facts2[0].Seq != 3 {
+		t.Fatalf("continuation must yield the 3rd fact as seq 3: %+v", facts2)
+	}
+}
+
+func TestTailReplayIsStable(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	// Tail from the same start cursor twice (a crash before committing the cursor) —
+	// must produce identical facts + seqs so usage-ingest dedups the replay.
+	a, _, _, _ := Tail(p, Cursor{}, 100)
+	b, _, _, _ := Tail(p, Cursor{}, 100)
+	if len(a) != len(b) {
+		t.Fatalf("replay length differs")
+	}
+	for i := range a {
+		if a[i].Seq != b[i].Seq || a[i].RunID != b[i].RunID {
+			t.Fatalf("replay not stable at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestTailRotationResetsOffsetKeepsSeq(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	_, next, _, _ := Tail(p, Cursor{}, 100) // NextSeq now 3, offset at EOF
+	// Rotate: replace the ledger with a fresh, SHORTER one (size < cursor.Offset).
+	if err := os.WriteFile(p, []byte(factLine("r3", "m")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	facts, after, rotated, _ := Tail(p, next, 100)
+	if !rotated {
+		t.Fatal("a shorter ledger than the cursor offset must be detected as rotated")
+	}
+	if len(facts) != 1 || facts[0].RunID != "r3" {
+		t.Fatalf("rotated ledger must re-read from the top: %+v", facts)
+	}
+	// seq continues monotonically (3), never colliding with the old file's 1/2.
+	if facts[0].Seq != 3 || after.NextSeq != 4 {
+		t.Fatalf("seq must stay monotonic across rotation: fact=%d next=%d", facts[0].Seq, after.NextSeq)
+	}
+}
+
+// The must-fix: a rename-and-recreate rotation where the NEW ledger is already
+// LARGER than the prior offset (so size < offset is FALSE) must still be detected by
+// file identity, or the new file's early facts are silently dropped.
+func TestTailRotationByIdentityWhenLargerThanOffset(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	_, next, _, _ := Tail(p, Cursor{}, 100) // NextSeq 3, offset at EOF, FileID captured
+	if next.FileID == 0 {
+		t.Skip("no inode identity on this platform; identity rotation detection unavailable")
+	}
+	oldOffset := next.Offset
+	// Rotate the logrotate way: RENAME the old ledger aside (the old inode stays held
+	// by the renamed file) and CREATE a fresh ledger at the path — so the new file is
+	// guaranteed a DIFFERENT inode even though it is LARGER than the old offset.
+	if err := os.Rename(p, p+".1"); err != nil {
+		t.Fatal(err)
+	}
+	bigger := factLine("n1", "m") + factLine("n2", "m") + factLine("n3", "m")
+	if err := os.WriteFile(p, []byte(bigger), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fi, _ := os.Stat(p)
+	if fi.Size() < oldOffset {
+		t.Fatalf("test setup: replacement (%d) must be >= old offset (%d) to exercise identity detection", fi.Size(), oldOffset)
+	}
+	facts, after, rotated, _ := Tail(p, next, 100)
+	if !rotated {
+		t.Fatal("a new-inode ledger larger than the offset must be detected as rotated (size check alone misses it)")
+	}
+	if len(facts) != 3 || facts[0].RunID != "n1" {
+		t.Fatalf("rotated larger ledger must re-read from the top: %+v", facts)
+	}
+	// seq stays monotonic across the rotation: 3, 4, 5 (never colliding with old 1/2).
+	if facts[0].Seq != 3 || facts[2].Seq != 5 || after.NextSeq != 6 {
+		t.Fatalf("seq must stay monotonic across identity rotation: %+v next=%d", facts, after.NextSeq)
+	}
+}
+
+func TestTailMissingLedgerIsIdle(t *testing.T) {
+	facts, next, _, err := Tail(filepath.Join(t.TempDir(), "nope.jsonl"), Cursor{Offset: 5, NextSeq: 2}, 100)
+	if err != nil {
+		t.Fatalf("missing ledger must not error: %v", err)
+	}
+	if len(facts) != 0 || next.Offset != 5 || next.NextSeq != 2 {
+		t.Fatalf("missing ledger must leave the cursor unchanged: %+v", next)
+	}
+}
+
+func p_helper(t *testing.T, content string) string { return writeLedger(t, content) }

--- a/internal/usageaxis/state.go
+++ b/internal/usageaxis/state.go
@@ -1,0 +1,97 @@
+package usageaxis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Cursor is the per-source resume point. Offset is the byte position in the ledger
+// up to which every fact has been confirmed-forwarded. NextSeq is the seq to assign
+// to the NEXT new fact — it is GLOBALLY monotonic per source and NEVER resets, even
+// across a ledger rotation, so usage-ingest's per-(org|source) seq high-water-mark
+// can drop a forwarder replay without dropping a genuinely new fact. FileID is the
+// ledger's filesystem identity (inode on unix; 0 when unsupported) used to detect a
+// rename-and-recreate rotation that a size check alone would miss.
+type Cursor struct {
+	Offset  int64  `json:"offset"`
+	NextSeq uint64 `json:"next_seq"`
+	FileID  uint64 `json:"file_id,omitempty"`
+}
+
+// State maps source_id -> Cursor. One forwarder instance tails one ledger today, but
+// the map shape matches the events cursors.json so multi-source is a later add.
+type State struct {
+	cursors map[string]Cursor
+}
+
+// NewState returns an empty State.
+func NewState() *State { return &State{cursors: map[string]Cursor{}} }
+
+// Get returns the cursor for a source (zero Cursor + false if unseen).
+func (s *State) Get(source string) (Cursor, bool) {
+	c, ok := s.cursors[source]
+	return c, ok
+}
+
+// Put stores the cursor for a source.
+func (s *State) Put(source string, c Cursor) { s.cursors[source] = c }
+
+// LoadState reads the JSON cursor file. A missing or malformed file yields an empty
+// State and a nil error (start from the top of the ledger).
+func LoadState(path string) (*State, error) {
+	st := NewState()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return st, nil
+	}
+	_ = json.Unmarshal(raw, &st.cursors) // malformed => stay empty
+	if st.cursors == nil {
+		st.cursors = map[string]Cursor{}
+	}
+	return st, nil
+}
+
+// SaveState atomically writes the JSON cursor file (temp sibling + rename). The
+// parent dir is 0700 and the temp file 0600 — the cursor file lists no secrets, but
+// keep it owner-only for consistency with the other axes.
+func SaveState(path string, st *State) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(st.cursors))
+	for k := range st.cursors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	ordered := make(map[string]Cursor, len(keys))
+	for _, k := range keys {
+		ordered[k] = st.cursors[k]
+	}
+	data, err := json.Marshal(ordered)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".cursors-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/usageaxis/usageaxis.go
+++ b/internal/usageaxis/usageaxis.go
@@ -1,0 +1,207 @@
+// Package usageaxis is the usage forwarder axis: it tails a Gas City's local
+// usage-fact ledger (.gc/usage.jsonl, written by gc's usage Sink), assigns each
+// fact a per-source monotonic seq, batches them, and POSTs each Batch to the
+// configured usage-ingest URL with the usage bearer. usage-ingest re-validates and
+// projects each fact into a manifold.spend row tagged source='estimated'.
+//
+// WHAT LEAVES THE BOX. Unlike the events axis (envelope-only, payload-stripped),
+// usage facts ARE numbers: tokens and a list-price cost estimate, plus the opaque
+// {run_id, session_id, step_id} correlation tuple and the model/provider labels.
+// There is no free text — no prompt, response, title, or path. This axis maps only
+// the closed set of usage.Fact fields into the wire Fact; anything gc adds that is
+// not one of them is dropped.
+//
+// AXIS ISOLATION. The usage bearer + config is SEPARATE from events' and recall's:
+// its own env set (GASWORKS_USAGE_*), its own saauth.Provider. One axis's token is
+// never usable by another.
+//
+// EGRESS GATE — SAFE BY DEFAULT. The axis is disabled (Enabled()==false) and never
+// constructs an HTTP client or dials unless a destination URL AND a token source AND
+// a source id AND a ledger path are all configured.
+package usageaxis
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gascity/gasworks/internal/saauth"
+)
+
+const (
+	defaultBatchMax     = 1000
+	defaultBatchEvery   = 5 * time.Second
+	minBatchEvery       = time.Second
+	defaultStateSubpath = "usage-forwarder"
+	defaultLedgerName   = "usage.jsonl"
+	// SchemaVersion is stamped on every Batch; usage-ingest rejects a mismatch. It
+	// is the usage wire contract version, independent of the events one.
+	SchemaVersion = 1
+	// KindModel is the only kind this axis forwards. Compute facts (wall-seconds, no
+	// model/tokens) are dropped at the source — usage-ingest would reject them, and
+	// shipping them wastes a round trip.
+	KindModel = "model"
+)
+
+// Fact is one usage fact on the wire: the gc usage.Fact JSON shape plus the
+// forwarder-assigned per-source Seq. Only the fields usage-ingest reads are mapped;
+// gc may carry others (idempotency_key, city, runtime, …) which are dropped.
+type Fact struct {
+	Seq uint64 `json:"seq"`
+
+	RunID     string `json:"run_id"`
+	SessionID string `json:"session_id"`
+	StepID    string `json:"step_id"`
+	Worker    string `json:"worker"`
+
+	Kind     string `json:"kind"`
+	Model    string `json:"model"`
+	Provider string `json:"provider"`
+
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+
+	CostUSDEstimate float64 `json:"cost_usd_estimate"`
+	Unpriced        bool    `json:"unpriced"`
+
+	UpstreamReqID string `json:"upstream_req_id"`
+	At            int64  `json:"at"`
+}
+
+// Batch is one POST body to usage-ingest.
+type Batch struct {
+	SourceID      string `json:"source_id"`
+	SchemaVersion int    `json:"schema_version"`
+	Facts         []Fact `json:"facts"`
+}
+
+// Config is the resolved usage-axis configuration. Build it with ConfigFromEnv.
+type Config struct {
+	// URL is the usage-ingest destination (trailing slash trimmed); "" => idle.
+	URL string
+	// SourceID is the opaque per-deployment id stamped on every Batch and used by
+	// usage-ingest as the dedup namespace. "" => idle.
+	SourceID string
+	// Ledger is the path to the gc usage.jsonl this axis tails.
+	Ledger string
+	// Token is the usage bearer source (file or env). Its OWN provider — never an
+	// events/recall token. Unconfigured => idle.
+	Token saauth.Provider
+	// StatePath is the resume-cursor file.
+	StatePath string
+	// BatchMax is the max facts per POST.
+	BatchMax int
+	// BatchInterval is the max time between POSTs.
+	BatchInterval time.Duration
+	// AllowHTTP opts in to a plain-http (loopback only) ingest URL for dev.
+	AllowHTTP bool
+}
+
+// Enabled is the egress gate: the axis may construct an HTTP client and dial ONLY
+// when a destination URL AND a source id AND a ledger path AND a token source are
+// all configured. When false the axis never builds a client or sends a request.
+func (c Config) Enabled() bool {
+	return c.URL != "" && c.SourceID != "" && c.Ledger != "" && c.Token.Configured()
+}
+
+// ConfigFromEnv builds a Config from GASWORKS_USAGE_* env. The token Provider prefers
+// GASWORKS_USAGE_TOKEN_FILE and falls back to GASWORKS_USAGE_TOKEN (popped from env,
+// dev-only). Returns a non-fatal warning string for the caller to log (never the
+// token value).
+//
+//	GASWORKS_USAGE_INGEST_URL     usage-ingest destination (https; "" => idle)
+//	GASWORKS_USAGE_SOURCE_ID      opaque per-deployment id ("" => idle)
+//	GASWORKS_USAGE_LEDGER         usage.jsonl path (default ~/.gc/usage.jsonl)
+//	GASWORKS_USAGE_TOKEN_FILE     bearer token file (preferred)
+//	GASWORKS_USAGE_TOKEN          bearer token (dev-only, popped from env)
+//	GASWORKS_USAGE_STATE          resume-cursor file (default XDG state dir)
+//	GASWORKS_USAGE_BATCH_MAX      max facts per POST (default 1000)
+//	GASWORKS_USAGE_BATCH_INTERVAL flush interval seconds (default 5)
+//	GASWORKS_USAGE_ALLOW_HTTP     "1" to allow loopback plain-http ingest (dev)
+func ConfigFromEnv() (Config, string) {
+	home, _ := os.UserHomeDir()
+	var warn string
+
+	token := func() saauth.Provider {
+		if fp := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_TOKEN_FILE")); fp != "" {
+			return saauth.FileProvider(fp)
+		}
+		if tok, ok := saauth.TokenFromEnv("GASWORKS_USAGE_TOKEN"); ok {
+			warn = saauth.EnvWarning
+			return saauth.EnvProvider(tok)
+		}
+		return saauth.Provider{}
+	}()
+
+	ledger := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_LEDGER"))
+	if ledger == "" {
+		ledger = filepath.Join(home, ".gc", defaultLedgerName)
+	}
+
+	state := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_STATE"))
+	if state == "" {
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		state = filepath.Join(stateHome, defaultStateSubpath, "cursors.json")
+	}
+
+	return Config{
+		URL:           strings.TrimRight(strings.TrimSpace(os.Getenv("GASWORKS_USAGE_INGEST_URL")), "/"),
+		SourceID:      strings.TrimSpace(os.Getenv("GASWORKS_USAGE_SOURCE_ID")),
+		Ledger:        ledger,
+		Token:         token,
+		StatePath:     state,
+		BatchMax:      envInt("GASWORKS_USAGE_BATCH_MAX", defaultBatchMax),
+		BatchInterval: envInterval("GASWORKS_USAGE_BATCH_INTERVAL", defaultBatchEvery),
+		AllowHTTP:     os.Getenv("GASWORKS_USAGE_ALLOW_HTTP") == "1",
+	}, warn
+}
+
+// URLOK enforces the https-only rule for the ingest destination: https with a host
+// is always allowed; plain http only with AllowHTTP and a loopback host.
+func URLOK(rawURL string, allowHTTP bool) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if u.Scheme == "https" && u.Host != "" {
+		return true
+	}
+	return u.Scheme == "http" && allowHTTP && (host == "localhost" || host == "127.0.0.1" || host == "::1")
+}
+
+func envInt(name string, def int) int {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return def
+	}
+	return n
+}
+
+func envInterval(name string, def time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	d := time.Duration(n) * time.Second
+	if d < minBatchEvery {
+		return minBatchEvery
+	}
+	return d
+}


### PR DESCRIPTION
## Phase 3 — the `usage` forwarder axis

A new **`usage`** axis on `gasworks-forwarder`, sibling to `recall` and `events`: it tails a Gas City's local gc usage ledger (`.gc/usage.jsonl`), assigns each model fact a per-source monotonic `seq`, batches, and POSTs to **usage-ingest** (Phase 2), which projects them into `source='estimated'` `manifold.spend` rows — closing the producer→pipe→ingest path so a self-hosted city's run costs show up in Gasworks.

### `internal/usageaxis`
- **Config / ConfigFromEnv** (`GASWORKS_USAGE_*`, its **own** bearer = axis isolation), the **egress gate** (`Enabled` — never dials unless URL + source id + ledger + token are all set), **URLOK** (https-only; loopback http only with `ALLOW_HTTP`).
- The wire `Fact`/`Batch` (field-for-field matching usage-ingest's `usagewire`), a crash-safe per-source `Cursor{offset, next_seq, file_id}`, the **file tailer**, and the **runner** (tail→batch→POST→commit-on-2xx). Hardened POST client: refuses redirects (bearer can't bounce hosts), TLS 1.2 floor, bounded timeout, token never logged.
- **`Tail`** forwards only COMPLETE lines, skips unparseable/non-model lines (offset advances, no `seq` consumed), leaves a partial trailing write, and keeps `NextSeq` **globally monotonic** across a rotation — so a crash-replay re-sends the same `seq`s and is idempotent under usage-ingest's high-water-mark.

### Crash-safety & the red-team must-fix
The cursor commits **only after a confirmed 2xx**; a failed POST holds it (the same facts re-POST). Rotation is detected by **file identity (inode)** *and* `size < offset`, so a logrotate **rename-and-recreate** whose new ledger is already larger than the old offset is no longer silently skipped (this was a confirmed data-loss finding). An empty-token cycle idles and holds the cursor rather than POSTing a bare `Bearer`.

### `cmd/gasworks-forwarder`
`usage` subcommand (+ `--once`) and a third `all` goroutine under the same `recover`+backoff supervisor (a usage panic never tears down recall/events).

### Verification & follow-ons
Whole module: `go test ./...` (13 pkgs) green · `vet` clean · `gofmt` clean. Adversarially red-teamed (4 lenses + verify); the two folded findings are above. **Follow-ons (separate):** the usage axis's systemd unit + README live in `gasworks-pack`; `SaveState` fsync + usage-ingest `maxSeq` rehydration are cross-axis durability items (display-plane only, never the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gascity/codesmith/gasworks/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784871006&installation_id=141368595&pr_number=41&repository=gascity%2Fgasworks&return_to=https%3A%2F%2Fgithub.com%2Fgascity%2Fgasworks%2Fpull%2F41&signature=eaca8b6bd0471748ba8cc7dc7611c94c3e9d310b1021a5e2be147e9cd905f7ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->