### PR TITLE
feat(events): envelope-first run_id/session_id/step_id correlation + opt-in content lift

### DIFF
--- a/cmd/gasworks-forwarder/main.go
+++ b/cmd/gasworks-forwarder/main.go
@@ -1,7 +1,7 @@
-// Command gasworks-forwarder ships coding-agent transcripts (recall) and redacted
-// city events (events) to their hosted ingest endpoints. Each AXIS — recall, events —
-// has its OWN config and OWN bearer credential: a recall raw-content token is never
-// shared with the events axis, and vice versa (axis isolation). The dispatch below
+// Command gasworks-forwarder ships coding-agent transcripts (recall), redacted city
+// events (events), and usage facts (usage) to their hosted ingest endpoints. Each
+// AXIS — recall, events, usage — has its OWN config and OWN bearer credential: one
+// axis's token is never shared with another (axis isolation). The dispatch below
 // builds each axis independently so a misconfigured or compromised axis cannot leak
 // its peer's credential.
 //
@@ -9,6 +9,7 @@
 //
 //	recall   run the recall transcript forwarder (RECALL_FORWARDER_* env)
 //	events   run the events forwarder (GASWORKS_EVENTS_* env)
+//	usage    run the usage forwarder, tailing .gc/usage.jsonl (GASWORKS_USAGE_* env)
 //	all      run every axis as independently-restartable goroutines (own config + bearer)
 //
 // Add --once to run a single scan pass and exit (recall only); default is the daemon
@@ -30,6 +31,7 @@ import (
 
 	"github.com/gascity/gasworks/internal/eventsaxis"
 	"github.com/gascity/gasworks/internal/recallaxis"
+	"github.com/gascity/gasworks/internal/usageaxis"
 	"github.com/gascity/gasworks/internal/version"
 )
 
@@ -51,6 +53,8 @@ func run(argv []string) int {
 		return runRecall(ctx, rest)
 	case "events":
 		return runEvents(ctx, rest)
+	case "usage":
+		return runUsage(ctx, rest)
 	case "all":
 		return runAll(ctx, rest)
 	case "version", "--version":
@@ -171,6 +175,52 @@ func runEvents(ctx context.Context, args []string) int {
 	return 0
 }
 
+// runUsage wires the usage axis from GASWORKS_USAGE_* env. It builds the axis's OWN
+// config + bearer and tails the gc usage ledger (.gc/usage.jsonl), forwarding model
+// facts to usage-ingest. With --once it drains to EOF and exits; otherwise it runs
+// the daemon loop.
+func runUsage(ctx context.Context, args []string) int {
+	once := false
+	for _, a := range args {
+		switch a {
+		case "--once":
+			once = true
+		case "-h", "--help":
+			eprintln("usage: gasworks-forwarder usage [--once]")
+			return 0
+		default:
+			eprintf("gasworks-forwarder usage: unknown flag %q", a)
+			return 2
+		}
+	}
+
+	cfg, warn := usageaxis.ConfigFromEnv()
+	if warn != "" {
+		eprintf("gasworks-forwarder: warning: %s", warn)
+	}
+
+	// Validate the destination scheme up front so a plain-http misconfig fails loudly
+	// instead of silently idling — but only when a URL was actually provided.
+	if cfg.URL != "" && !usageaxis.URLOK(cfg.URL, cfg.AllowHTTP) {
+		eprintln("gasworks-forwarder usage: GASWORKS_USAGE_INGEST_URL must be https:// (or localhost http with GASWORKS_USAGE_ALLOW_HTTP=1)")
+		return 1
+	}
+	if !cfg.Enabled() {
+		eprintln("gasworks-forwarder usage: idle — GASWORKS_USAGE_INGEST_URL / _SOURCE_ID / _LEDGER / token not all set (opt in to enable)")
+	}
+
+	runner := usageaxis.NewRunner(cfg, logf)
+	run := runner.Run
+	if once {
+		run = runner.RunOnce
+	}
+	if err := run(ctx); err != nil {
+		eprintf("gasworks-forwarder usage: %v", err)
+		return 1
+	}
+	return 0
+}
+
 // runAll runs recall AND events concurrently, each in its own goroutine with a
 // per-axis recover() + backoff supervisor. This reinstates in-process the isolation
 // the two axes have as separate systemd units: one axis panicking, or its source
@@ -209,7 +259,7 @@ func runAll(ctx context.Context, args []string) int {
 		}
 	)
 
-	wg.Add(2)
+	wg.Add(3)
 	go func() {
 		defer wg.Done()
 		recordCode(superviseAxis(ctx, "recall", func() int { return runRecall(ctx, nil) }))
@@ -217,6 +267,10 @@ func runAll(ctx context.Context, args []string) int {
 	go func() {
 		defer wg.Done()
 		recordCode(superviseAxis(ctx, "events", func() int { return runEvents(ctx, nil) }))
+	}()
+	go func() {
+		defer wg.Done()
+		recordCode(superviseAxis(ctx, "usage", func() int { return runUsage(ctx, nil) }))
 	}()
 	wg.Wait()
 	return worst
@@ -286,15 +340,16 @@ func eprintf(format string, args ...any) { fmt.Fprintf(os.Stderr, format+"\n", a
 func eprintln(s string)                  { fmt.Fprintln(os.Stderr, s) }
 
 func usage() {
-	const u = `gasworks-forwarder: ship coding-agent transcripts (recall) and redacted city events to hosted ingest.
+	const u = `gasworks-forwarder: ship coding-agent transcripts (recall), redacted city events (events), and usage facts (usage) to hosted ingest.
 
 Usage:
   gasworks-forwarder recall [--once]   run the recall transcript forwarder
   gasworks-forwarder events            run the events forwarder (tails the supervisor SSE)
+  gasworks-forwarder usage  [--once]   run the usage forwarder (tails .gc/usage.jsonl)
   gasworks-forwarder all               run every axis (own goroutine + recover + backoff)
 
-Each axis has its OWN config + bearer credential (axis isolation): a recall raw-content
-token is never usable by the events axis, and vice versa. The recall axis is configured
-via RECALL_FORWARDER_* env; the events axis via GASWORKS_EVENTS_* env (see the package docs).`
+Each axis has its OWN config + bearer credential (axis isolation): one axis's token is
+never usable by another. recall is configured via RECALL_FORWARDER_* env; events via
+GASWORKS_EVENTS_* env; usage via GASWORKS_USAGE_* env (see the package docs).`
 	fmt.Fprintln(os.Stderr, u)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gascity/gasworks
 go 1.26.4
 
 require (
-	github.com/gastownhall/gascity v1.1.1-0.20260623105741-7f39639d10e4
+	github.com/gastownhall/gascity v1.1.1-0.20260625212128-87de14874a96
 	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/sys v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gastownhall/gascity v1.1.1-0.20260623105741-7f39639d10e4 h1:etqaLgALN8GLpwVn5zsLQcQqXblOkD4C2p6Lveo/W24=
 github.com/gastownhall/gascity v1.1.1-0.20260623105741-7f39639d10e4/go.mod h1:5JJlHcDWGZd2zQ+p709xihilBiLr7oLT9hTLeLa9g0M=
+github.com/gastownhall/gascity v1.1.1-0.20260625212128-87de14874a96 h1:Gp0Y0dHFcmvrd79KH3dUDg2Hzv+vWOYA4UAeQx7Paxg=
+github.com/gastownhall/gascity v1.1.1-0.20260625212128-87de14874a96/go.mod h1:5JJlHcDWGZd2zQ+p709xihilBiLr7oLT9hTLeLa9g0M=
 github.com/gastownhall/gascity-packs v0.3.1-0.20260617013242-33d3a430a67d/go.mod h1:OHqPd055b+3Q93mZqxdwTk2/3sz+xxCBUWlggvuRnMk=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/eventsaxis/content_test.go
+++ b/internal/eventsaxis/content_test.go
@@ -6,11 +6,12 @@ import (
 )
 
 func TestLiftContent(t *testing.T) {
-	payload := json.RawMessage(`{"bead":{"id":"mc-1","title":"ESCALATION: JSONL spike [HIGH]","metadata":{"gc.step_id":"review-pipeline.synthesize","gc.step_ref":"mol-randy-triage-patrol.apply"}}}`)
+	payload := json.RawMessage(`{"bead":{"id":"mc-1","title":"ESCALATION: JSONL spike [HIGH]","metadata":{"gc.active_work_bead":"review-pipeline.synthesize","gc.step_id":"ignored","gc.step_ref":"mol-randy-triage-patrol.apply"}}}`)
 	title, stepID, formula := liftContent(payload)
 	if title != "ESCALATION: JSONL spike [HIGH]" {
 		t.Errorf("title = %q", title)
 	}
+	// step_id is gc.active_work_bead (the manifold.spend.step_id join key), NOT gc.step_id.
 	if stepID != "review-pipeline.synthesize" {
 		t.Errorf("step_id = %q", stepID)
 	}

--- a/internal/eventsaxis/content_test.go
+++ b/internal/eventsaxis/content_test.go
@@ -6,14 +6,18 @@ import (
 )
 
 func TestLiftContent(t *testing.T) {
-	payload := json.RawMessage(`{"bead":{"id":"mc-1","title":"ESCALATION: JSONL spike [HIGH]","metadata":{"gc.active_work_bead":"review-pipeline.synthesize","gc.step_id":"ignored","gc.step_ref":"mol-randy-triage-patrol.apply"}}}`)
-	title, stepID, formula := liftContent(payload)
+	payload := json.RawMessage(`{"bead":{"id":"mc-1","title":"ESCALATION: JSONL spike [HIGH]","metadata":{"gc.step_id":"synthesize","gc.root_bead_id":"mc-m8afp","gc.step_ref":"mol-randy-triage-patrol.apply"}}}`)
+	title, stepID, runID, formula := liftContent(payload)
 	if title != "ESCALATION: JSONL spike [HIGH]" {
 		t.Errorf("title = %q", title)
 	}
-	// step_id is gc.active_work_bead (the manifold.spend.step_id join key), NOT gc.step_id.
-	if stepID != "review-pipeline.synthesize" {
+	// step_id = the work bead's gc.step_id (the run-step), NOT gc.active_work_bead.
+	if stepID != "synthesize" {
 		t.Errorf("step_id = %q", stepID)
+	}
+	// run_id = gc.root_bead_id (the run-root) so the events plane has a run key.
+	if runID != "mc-m8afp" {
+		t.Errorf("run_id = %q, want mc-m8afp", runID)
 	}
 	if formula != "randy-triage-patrol" {
 		t.Errorf("formula (from step_ref) = %q, want randy-triage-patrol", formula)
@@ -21,15 +25,15 @@ func TestLiftContent(t *testing.T) {
 
 	// gc.formula_name wins over the step_ref derivation when present.
 	withName := json.RawMessage(`{"bead":{"title":"t","metadata":{"gc.formula_name":"explicit-name","gc.step_ref":"mol-other.x"}}}`)
-	if _, _, f := liftContent(withName); f != "explicit-name" {
+	if _, _, _, f := liftContent(withName); f != "explicit-name" {
 		t.Errorf("gc.formula_name should win, got %q", f)
 	}
 
 	// Malformed / empty payloads are best-effort: empties, never a panic.
 	for _, bad := range []json.RawMessage{nil, json.RawMessage(`{`), json.RawMessage(`{"bead":null}`), json.RawMessage(`[]`)} {
-		ti, si, fo := liftContent(bad)
-		if ti != "" || si != "" || fo != "" {
-			t.Errorf("malformed payload %q should yield empties, got %q/%q/%q", bad, ti, si, fo)
+		ti, si, ri, fo := liftContent(bad)
+		if ti != "" || si != "" || ri != "" || fo != "" {
+			t.Errorf("malformed payload %q should yield empties, got %q/%q/%q/%q", bad, ti, si, ri, fo)
 		}
 	}
 }

--- a/internal/eventsaxis/content_test.go
+++ b/internal/eventsaxis/content_test.go
@@ -1,0 +1,50 @@
+package eventsaxis
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLiftContent(t *testing.T) {
+	payload := json.RawMessage(`{"bead":{"id":"mc-1","title":"ESCALATION: JSONL spike [HIGH]","metadata":{"gc.step_id":"review-pipeline.synthesize","gc.step_ref":"mol-randy-triage-patrol.apply"}}}`)
+	title, stepID, formula := liftContent(payload)
+	if title != "ESCALATION: JSONL spike [HIGH]" {
+		t.Errorf("title = %q", title)
+	}
+	if stepID != "review-pipeline.synthesize" {
+		t.Errorf("step_id = %q", stepID)
+	}
+	if formula != "randy-triage-patrol" {
+		t.Errorf("formula (from step_ref) = %q, want randy-triage-patrol", formula)
+	}
+
+	// gc.formula_name wins over the step_ref derivation when present.
+	withName := json.RawMessage(`{"bead":{"title":"t","metadata":{"gc.formula_name":"explicit-name","gc.step_ref":"mol-other.x"}}}`)
+	if _, _, f := liftContent(withName); f != "explicit-name" {
+		t.Errorf("gc.formula_name should win, got %q", f)
+	}
+
+	// Malformed / empty payloads are best-effort: empties, never a panic.
+	for _, bad := range []json.RawMessage{nil, json.RawMessage(`{`), json.RawMessage(`{"bead":null}`), json.RawMessage(`[]`)} {
+		ti, si, fo := liftContent(bad)
+		if ti != "" || si != "" || fo != "" {
+			t.Errorf("malformed payload %q should yield empties, got %q/%q/%q", bad, ti, si, fo)
+		}
+	}
+}
+
+func TestFormulaFromStepRef(t *testing.T) {
+	cases := map[string]string{
+		"mol-randy-triage-patrol.apply":              "randy-triage-patrol",
+		"mol-seth-patrol.patrol":                     "seth-patrol",
+		"mol-randy-triage-patrol.report-scope-check": "randy-triage-patrol",
+		"mol-bare":      "bare", // no step suffix
+		"not-a-mol-ref": "",     // wrong prefix
+		"":              "",
+	}
+	for ref, want := range cases {
+		if got := formulaFromStepRef(ref); got != want {
+			t.Errorf("formulaFromStepRef(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}

--- a/internal/eventsaxis/eventsaxis.go
+++ b/internal/eventsaxis/eventsaxis.go
@@ -68,6 +68,12 @@ type Config struct {
 	Salt []byte
 	// ExportRef includes the id-gated ref (opaque bead/convoy ids only).
 	ExportRef bool
+	// EmitContent opts in to lifting free-form content (bead title, run formula)
+	// plus the opaque gc.step_id off the SSE payload. It REVERSES the envelope-only
+	// default and also turns on the opaque correlation ids (run_id/session_id/
+	// step_id), since step_id is the join key those content fields exist for. Set
+	// ONLY under an explicit operator/org content opt-in; default false.
+	EmitContent bool
 	// StatePath is the per-city cursor file (resume point).
 	StatePath string
 	// BatchMax is the max events per POST.
@@ -100,6 +106,8 @@ func (c Config) Enabled() bool {
 //	GASWORKS_EVENTS_TOKEN         bearer token (dev-only, popped from env)
 //	GASWORKS_EVENTS_SALT          actor-hash salt (>= 16 bytes or events are dropped)
 //	GASWORKS_EVENTS_EXPORT_REF    include the id-gated ref (default on)
+//	GASWORKS_EVENTS_EMIT_CONTENT  "1" to lift bead title + run formula + gc.step_id
+//	                              off the payload (default off; REVERSES envelope-only)
 //	GASWORKS_EVENTS_STATE         cursor file (default XDG state dir)
 //	GASWORKS_EVENTS_BATCH_MAX     max events per POST (default 1000)
 //	GASWORKS_EVENTS_BATCH_INTERVAL flush interval seconds (default 5)
@@ -140,6 +148,7 @@ func ConfigFromEnv() (Config, string) {
 		Token:         tokenProvider,
 		Salt:          []byte(os.Getenv("GASWORKS_EVENTS_SALT")),
 		ExportRef:     envBool("GASWORKS_EVENTS_EXPORT_REF", true),
+		EmitContent:   envBool("GASWORKS_EVENTS_EMIT_CONTENT", false),
 		StatePath:     state,
 		BatchMax:      envInt("GASWORKS_EVENTS_BATCH_MAX", defaultBatchMax),
 		BatchInterval: envInterval("GASWORKS_EVENTS_BATCH_INTERVAL", defaultBatchEvery),

--- a/internal/eventsaxis/eventsaxis.go
+++ b/internal/eventsaxis/eventsaxis.go
@@ -12,9 +12,11 @@
 // Payload are never read into any field — and pkg/eventexport reduces that to a
 // fixed envelope (type, time, salted actor hash, id-gated ref). An unknown or
 // non-allowlisted type is dropped, and the envelope is a closed struct so a newly
-// added source field can never escape. run_id/session_id ship EMPTY in v0
-// (EmitCorrelation stays off inside the pkg until a typed-at-record-site source
-// lands), so this axis does NOT parse them off the SSE payload.
+// added source field can never escape. The opaque run_id/session_id/step_id
+// correlation ids ARE carried — read straight off the envelope (the typed,
+// record-site source: the producer stamps them per event), safeRef-gated by
+// pkg/eventexport and emitted under EmitCorrelation. They are system-generated ids,
+// NOT free-form content; the envelope-only content boundary above is unchanged.
 //
 // AXIS ISOLATION.
 // The events bearer + config is SEPARATE from recall's: its own env set
@@ -68,11 +70,18 @@ type Config struct {
 	Salt []byte
 	// ExportRef includes the id-gated ref (opaque bead/convoy ids only).
 	ExportRef bool
-	// EmitContent opts in to lifting free-form content (bead title, run formula)
-	// plus the opaque gc.step_id off the SSE payload. It REVERSES the envelope-only
-	// default and also turns on the opaque correlation ids (run_id/session_id/
-	// step_id), since step_id is the join key those content fields exist for. Set
-	// ONLY under an explicit operator/org content opt-in; default false.
+	// EmitCorrelation emits the opaque run_id/session_id/step_id correlation ids
+	// (PII-free, safeRef-gated by pkg/eventexport). They are read off the envelope —
+	// the producer stamps them per event — so this is NOT a content opt-in; default
+	// true now that a typed record-site source lands them. A producer that predates
+	// the envelope fields sends them empty (nothing is emitted). Set false to fall
+	// back to the envelope-minimal shape.
+	EmitCorrelation bool
+	// EmitContent opts in to lifting free-form content (bead title, run formula) off
+	// the SSE payload. It REVERSES the envelope-only default — set ONLY under an
+	// explicit operator/org content opt-in; default false. It additionally lets
+	// liftContent derive run_id/step_id from the payload as a fallback for producers
+	// that predate the envelope correlation fields.
 	EmitContent bool
 	// StatePath is the per-city cursor file (resume point).
 	StatePath string
@@ -106,8 +115,10 @@ func (c Config) Enabled() bool {
 //	GASWORKS_EVENTS_TOKEN         bearer token (dev-only, popped from env)
 //	GASWORKS_EVENTS_SALT          actor-hash salt (>= 16 bytes or events are dropped)
 //	GASWORKS_EVENTS_EXPORT_REF    include the id-gated ref (default on)
-//	GASWORKS_EVENTS_EMIT_CONTENT  "1" to lift bead title + run formula + gc.step_id
-//	                              off the payload (default off; REVERSES envelope-only)
+//	GASWORKS_EVENTS_EMIT_CORRELATION  emit opaque run_id/session_id/step_id off the
+//	                              envelope (default ON; PII-free ids, "0" to disable)
+//	GASWORKS_EVENTS_EMIT_CONTENT  "1" to lift bead title + run formula off the payload
+//	                              (default off; REVERSES envelope-only)
 //	GASWORKS_EVENTS_STATE         cursor file (default XDG state dir)
 //	GASWORKS_EVENTS_BATCH_MAX     max events per POST (default 1000)
 //	GASWORKS_EVENTS_BATCH_INTERVAL flush interval seconds (default 5)
@@ -142,17 +153,18 @@ func ConfigFromEnv() (Config, string) {
 	}
 
 	return Config{
-		URL:           strings.TrimRight(strings.TrimSpace(os.Getenv("GASWORKS_EVENTS_INGEST_URL")), "/"),
-		Supervisor:    strings.TrimRight(supervisor, "/"),
-		Cities:        splitCities(os.Getenv("GASWORKS_EVENTS_CITIES")),
-		Token:         tokenProvider,
-		Salt:          []byte(os.Getenv("GASWORKS_EVENTS_SALT")),
-		ExportRef:     envBool("GASWORKS_EVENTS_EXPORT_REF", true),
-		EmitContent:   envBool("GASWORKS_EVENTS_EMIT_CONTENT", false),
-		StatePath:     state,
-		BatchMax:      envInt("GASWORKS_EVENTS_BATCH_MAX", defaultBatchMax),
-		BatchInterval: envInterval("GASWORKS_EVENTS_BATCH_INTERVAL", defaultBatchEvery),
-		AllowHTTP:     os.Getenv("GASWORKS_EVENTS_ALLOW_HTTP") == "1",
+		URL:             strings.TrimRight(strings.TrimSpace(os.Getenv("GASWORKS_EVENTS_INGEST_URL")), "/"),
+		Supervisor:      strings.TrimRight(supervisor, "/"),
+		Cities:          splitCities(os.Getenv("GASWORKS_EVENTS_CITIES")),
+		Token:           tokenProvider,
+		Salt:            []byte(os.Getenv("GASWORKS_EVENTS_SALT")),
+		ExportRef:       envBool("GASWORKS_EVENTS_EXPORT_REF", true),
+		EmitCorrelation: envBool("GASWORKS_EVENTS_EMIT_CORRELATION", true),
+		EmitContent:     envBool("GASWORKS_EVENTS_EMIT_CONTENT", false),
+		StatePath:       state,
+		BatchMax:        envInt("GASWORKS_EVENTS_BATCH_MAX", defaultBatchMax),
+		BatchInterval:   envInterval("GASWORKS_EVENTS_BATCH_INTERVAL", defaultBatchEvery),
+		AllowHTTP:       os.Getenv("GASWORKS_EVENTS_ALLOW_HTTP") == "1",
 	}, warn
 }
 

--- a/internal/eventsaxis/eventsaxis_test.go
+++ b/internal/eventsaxis/eventsaxis_test.go
@@ -118,13 +118,16 @@ func TestRunner_DisabledNeverDials(t *testing.T) {
 // only ever read the typed primitive fields). Message/Payload carry free-form
 // content that must NEVER reach the exported batch.
 type sseEvent struct {
-	Seq     uint64 `json:"seq"`
-	Type    string `json:"type"`
-	TS      string `json:"ts"`
-	Actor   string `json:"actor"`
-	Subject string `json:"subject"`
-	Message string `json:"message,omitempty"`
-	Payload string `json:"payload,omitempty"`
+	Seq       uint64 `json:"seq"`
+	Type      string `json:"type"`
+	TS        string `json:"ts"`
+	Actor     string `json:"actor"`
+	Subject   string `json:"subject"`
+	RunID     string `json:"run_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	StepID    string `json:"step_id,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Payload   string `json:"payload,omitempty"`
 }
 
 // sseServer streams a fixed slice of events as SSE for one city, honoring after_seq,
@@ -359,9 +362,140 @@ func TestSource_HeartbeatAndMalformedTolerated(t *testing.T) {
 	if !te.Ts.Equal(mustTime("2026-06-21T10:00:00Z")) {
 		t.Fatalf("ts = %v, want parsed RFC3339", te.Ts)
 	}
-	// run_id/session_id must stay empty in v0 (never decoded off the payload).
-	if te.RunID != "" || te.SessionID != "" {
-		t.Fatalf("run_id/session_id must be empty in v0, got %q/%q", te.RunID, te.SessionID)
+	// This envelope carries no correlation ids and there is no content opt-in, so the
+	// projected event stays empty (the producer simply didn't stamp them).
+	if te.RunID != "" || te.SessionID != "" || te.StepID != "" {
+		t.Fatalf("correlation ids must be empty when the envelope omits them, got %q/%q/%q", te.RunID, te.SessionID, te.StepID)
+	}
+}
+
+// TestDispatch_EnvelopeCorrelation proves run_id/session_id/step_id are read off the
+// envelope with no content opt-in, that the payload metadata is only a fallback for
+// producers that omit them, and that the envelope value always wins.
+func TestDispatch_EnvelopeCorrelation(t *testing.T) {
+	cases := []struct {
+		name                           string
+		data                           string
+		emitContent                    bool
+		wantRun, wantSession, wantStep string
+	}{
+		{
+			name:    "envelope ids, no content opt-in",
+			data:    `{"seq":1,"type":"bead.created","ts":"2026-06-27T00:00:00Z","actor":"a","run_id":"mc-root","session_id":"mc-sess","step_id":"synthesize"}`,
+			wantRun: "mc-root", wantSession: "mc-sess", wantStep: "synthesize",
+		},
+		{
+			name:        "no envelope ids + content opt-in -> payload fallback for run/step, session empty",
+			data:        `{"seq":2,"type":"bead.created","ts":"2026-06-27T00:00:00Z","actor":"a","payload":{"bead":{"title":"T","metadata":{"gc.root_bead_id":"mc-fallback","gc.step_id":"apply"}}}}`,
+			emitContent: true,
+			wantRun:     "mc-fallback", wantStep: "apply",
+		},
+		{
+			name:        "envelope wins over payload metadata",
+			data:        `{"seq":3,"type":"bead.created","ts":"2026-06-27T00:00:00Z","actor":"a","run_id":"mc-env","step_id":"env-step","payload":{"bead":{"metadata":{"gc.root_bead_id":"mc-payload","gc.step_id":"payload-step"}}}}`,
+			emitContent: true,
+			wantRun:     "mc-env", wantStep: "env-step",
+		},
+		{
+			name: "no envelope ids, no content opt-in -> empty",
+			data: `{"seq":4,"type":"session.woke","ts":"2026-06-27T00:00:00Z","actor":"a"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &sseSource{events: make(chan eventexport.TaggedEvent, 1), emitContent: tc.emitContent}
+			if !s.dispatch(context.Background(), "c1", []byte(tc.data)) {
+				t.Fatal("dispatch returned false without a ctx cancel")
+			}
+			te := <-s.events
+			if te.RunID != tc.wantRun {
+				t.Errorf("RunID = %q, want %q", te.RunID, tc.wantRun)
+			}
+			if te.SessionID != tc.wantSession {
+				t.Errorf("SessionID = %q, want %q", te.SessionID, tc.wantSession)
+			}
+			if te.StepID != tc.wantStep {
+				t.Errorf("StepID = %q, want %q", te.StepID, tc.wantStep)
+			}
+		})
+	}
+}
+
+// TestRunner_EmitsEnvelopeCorrelation proves the opaque envelope correlation ids flow
+// end-to-end through the projection under EmitCorrelation — WITHOUT the content opt-in —
+// and are withheld when EmitCorrelation is off.
+func TestRunner_EmitsEnvelopeCorrelation(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		emitCorrelation bool
+		wantRun         string
+	}{
+		{"correlation on -> run_id flows", true, "mc-root-bead"},
+		{"correlation off -> envelope-minimal", false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []sseEvent{{
+				Seq: 1, Type: "bead.closed", TS: "2026-06-27T10:00:00Z", Actor: "alice", Subject: "mc-wisp-1",
+				RunID: "mc-root-bead", SessionID: "mc-sess-bead", StepID: "synthesize",
+			}}
+			sse := sseServer(t, events)
+			defer sse.Close()
+			ing := &ingestCapture{}
+			ingest := httptest.NewServer(http.HandlerFunc(ing.handler))
+			defer ingest.Close()
+
+			cfg := Config{
+				URL: ingest.URL, Supervisor: sse.URL, Cities: []string{"c1"},
+				Token: saauth.EnvProvider("b"), Salt: testSalt,
+				ExportRef:       true,
+				EmitCorrelation: tc.emitCorrelation, // EmitContent stays OFF
+				StatePath:       t.TempDir() + "/cursors.json",
+				BatchMax:        100, BatchInterval: 15 * time.Millisecond, AllowHTTP: true,
+			}
+			r := NewRunner(cfg, func(string, ...any) {})
+			r.client = sse.Client()
+			r.postClient = ingest.Client()
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() { _ = r.Run(ctx); close(done) }()
+			waitFor(t, 3*time.Second, func() bool {
+				bs, _, _ := ing.snapshot()
+				for _, b := range bs {
+					for _, e := range b.Events {
+						if e.Seq == 1 {
+							return true
+						}
+					}
+				}
+				return false
+			})
+			cancel()
+			<-done
+
+			batches, _, blob := ing.snapshot()
+			var gotRun, gotSession, gotStep string
+			for _, b := range batches {
+				for _, e := range b.Events {
+					if e.Seq == 1 {
+						gotRun, gotSession, gotStep = e.RunID, e.SessionID, e.StepID
+					}
+				}
+			}
+			if gotRun != tc.wantRun {
+				t.Fatalf("exported run_id = %q, want %q", gotRun, tc.wantRun)
+			}
+			if tc.emitCorrelation {
+				if gotSession != "mc-sess-bead" || gotStep != "synthesize" {
+					t.Fatalf("exported session/step = %q/%q, want mc-sess-bead/synthesize", gotSession, gotStep)
+				}
+			} else if gotSession != "" || gotStep != "" {
+				t.Fatalf("correlation off: session/step must be empty, got %q/%q", gotSession, gotStep)
+			}
+			// EmitContent is OFF, so no free-form content rides along even with correlation on.
+			if strings.Contains(blob, `"title"`) || strings.Contains(blob, `"formula"`) {
+				t.Fatalf("content leaked with EmitContent off:\n%s", blob)
+			}
+		})
 	}
 }
 

--- a/internal/eventsaxis/runner.go
+++ b/internal/eventsaxis/runner.go
@@ -120,8 +120,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		TokenProvider: r.cfg.Token.Token,
 		Salt:          r.cfg.Salt,
 		ExportRef:     r.cfg.ExportRef,
-		BatchMax:      r.cfg.BatchMax,
-		BatchInterval: r.cfg.BatchInterval,
+		// The content opt-in also turns on the opaque correlation ids: step_id is the
+		// join key the title/formula content exists to support, so they light up together.
+		EmitContent:     r.cfg.EmitContent,
+		EmitCorrelation: r.cfg.EmitContent,
+		BatchMax:        r.cfg.BatchMax,
+		BatchInterval:   r.cfg.BatchInterval,
 		// The ingest POST uses its OWN bounded-timeout client, NOT the no-timeout SSE
 		// client, so a hung endpoint can't stall the export loop (L3).
 		Client: r.postClient,

--- a/internal/eventsaxis/runner.go
+++ b/internal/eventsaxis/runner.go
@@ -120,10 +120,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		TokenProvider: r.cfg.Token.Token,
 		Salt:          r.cfg.Salt,
 		ExportRef:     r.cfg.ExportRef,
-		// The content opt-in also turns on the opaque correlation ids: step_id is the
-		// join key the title/formula content exists to support, so they light up together.
+		// Correlation ids (opaque run_id/session_id/step_id) ride the envelope and are
+		// independent of the free-form content opt-in — they have their own gate.
 		EmitContent:     r.cfg.EmitContent,
-		EmitCorrelation: r.cfg.EmitContent,
+		EmitCorrelation: r.cfg.EmitCorrelation,
 		BatchMax:        r.cfg.BatchMax,
 		BatchInterval:   r.cfg.BatchInterval,
 		// The ingest POST uses its OWN bounded-timeout client, NOT the no-timeout SSE

--- a/internal/eventsaxis/source.go
+++ b/internal/eventsaxis/source.go
@@ -55,7 +55,13 @@ func liftContent(payload json.RawMessage) (title, stepID, formula string) {
 	}
 	title = bp.Bead.Title
 	if m := bp.Bead.Metadata; m != nil {
-		stepID = m["gc.step_id"]
+		// step_id = gc.active_work_bead — the logical formula-step id, byte-equal to
+		// manifold.spend.step_id (the usage Fact.StepID source, #3708), so the step->
+		// spend join is exact. NOT gc.step_id.
+		stepID = m["gc.active_work_bead"]
+		// formula = the run's recipe name. Prefer the canonical gc.formula_name (the
+		// producer stamps it on the run-root); fall back to deriving it from the
+		// step bead's gc.step_ref "mol-<formula>.<step>" prefix until that lands.
 		if formula = m["gc.formula_name"]; formula == "" {
 			formula = formulaFromStepRef(m["gc.step_ref"])
 		}

--- a/internal/eventsaxis/source.go
+++ b/internal/eventsaxis/source.go
@@ -16,18 +16,24 @@ import (
 )
 
 // rawEvent is the slice of a supervisor SSE event we decode. seq/type/ts/actor/
-// subject are always read. Payload is decoded ONLY when content emission is opted
-// in (Config.EmitContent): liftContent then extracts the bead title + the opaque
-// gc.step_id / run-formula metadata from it. With the opt-in OFF (the default) the
-// payload is ignored and no free-form content is lifted — the envelope-only
-// contract holds. (run_id/session_id ship empty in v0; we do not decode them.)
+// subject and the run_id/session_id/step_id correlation ids are read straight off
+// the envelope — they are opaque, system-generated ids (PII-free), so they ride the
+// envelope-only contract and need no content opt-in. The producer stamps them on
+// every event (run_id resolves to the run-root bead id, never empty). Producers that
+// predate the envelope fields send them empty; liftContent then re-derives
+// run_id/step_id from the payload as a fallback (under the content opt-in only).
+// Payload itself is decoded ONLY under Config.EmitContent, when liftContent lifts the
+// free-form bead title + run-formula.
 type rawEvent struct {
-	Seq     uint64          `json:"seq"`
-	Type    string          `json:"type"`
-	TS      string          `json:"ts"`
-	Actor   string          `json:"actor"`
-	Subject string          `json:"subject"`
-	Payload json.RawMessage `json:"payload"`
+	Seq       uint64          `json:"seq"`
+	Type      string          `json:"type"`
+	TS        string          `json:"ts"`
+	Actor     string          `json:"actor"`
+	Subject   string          `json:"subject"`
+	RunID     string          `json:"run_id"`
+	SessionID string          `json:"session_id"`
+	StepID    string          `json:"step_id"`
+	Payload   json.RawMessage `json:"payload"`
 }
 
 // beadPayload is the minimal slice of a bead.* event payload read under the
@@ -218,11 +224,12 @@ func (s *sseSource) streamOnce(ctx context.Context, city string) error {
 }
 
 // dispatch decodes one SSE `data:` payload into a TaggedEvent — mapping the typed
-// primitive fields, plus (only under the EmitContent opt-in) the bead title +
-// gc.step_id/run-formula lifted from the payload via liftContent — and hands it to
-// the exporter. It returns false only when ctx is cancelled (shutting down). A
-// payload that fails to parse, or whose ts is unparseable, is dropped quietly: the
-// projector would reject it anyway, and a malformed line must not kill the stream.
+// primitive fields + the opaque run_id/session_id/step_id correlation ids off the
+// envelope, plus (only under the EmitContent opt-in) the bead title + run-formula
+// lifted from the payload via liftContent — and hands it to the exporter. It returns
+// false only when ctx is cancelled (shutting down). A payload that fails to parse, or
+// whose ts is unparseable, is dropped quietly: the projector would reject it anyway,
+// and a malformed line must not kill the stream.
 func (s *sseSource) dispatch(ctx context.Context, city string, data []byte) bool {
 	var r rawEvent
 	if err := json.Unmarshal(data, &r); err != nil {
@@ -235,12 +242,28 @@ func (s *sseSource) dispatch(ctx context.Context, city string, data []byte) bool
 		Ts:      parseTS(r.TS),
 		Actor:   r.Actor,
 		Subject: r.Subject,
-		// RunID/SessionID intentionally left empty in v0.
+		// Opaque correlation ids straight off the envelope (PII-free; the projection
+		// safeRef-gates them and emits them only under EmitCorrelation). Empty on
+		// producers that predate the envelope fields — then re-derived from the payload
+		// below under the content opt-in.
+		RunID:     r.RunID,
+		SessionID: r.SessionID,
+		StepID:    r.StepID,
 	}
 	if s.emitContent {
 		// The ONLY place this axis reads the SSE payload, reached solely under the
-		// content opt-in: lift the bead title + opaque run_id/step_id + run-formula.
-		te.Title, te.StepID, te.RunID, te.Formula = liftContent(r.Payload)
+		// content opt-in: lift the bead title + run-formula. For producers that don't
+		// yet carry the ids on the envelope, derive run_id/step_id from the payload
+		// metadata (gc.root_bead_id/gc.step_id) as a fallback — the envelope value wins
+		// when present. session_id has no payload source.
+		title, stepID, runID, formula := liftContent(r.Payload)
+		te.Title, te.Formula = title, formula
+		if te.RunID == "" {
+			te.RunID = runID
+		}
+		if te.StepID == "" {
+			te.StepID = stepID
+		}
 	}
 	select {
 	case s.events <- te:

--- a/internal/eventsaxis/source.go
+++ b/internal/eventsaxis/source.go
@@ -45,20 +45,25 @@ type beadPayload struct {
 // prefix). Best-effort: a malformed or absent payload yields empties, never an
 // error — a bad payload must never wedge the stream. This is the ONLY place the
 // axis reads the SSE payload, reached solely when Config.EmitContent is set.
-func liftContent(payload json.RawMessage) (title, stepID, formula string) {
+func liftContent(payload json.RawMessage) (title, stepID, runID, formula string) {
 	if len(payload) == 0 {
-		return "", "", ""
+		return "", "", "", ""
 	}
 	var bp beadPayload
 	if err := json.Unmarshal(payload, &bp); err != nil {
-		return "", "", ""
+		return "", "", "", ""
 	}
 	title = bp.Bead.Title
 	if m := bp.Bead.Metadata; m != nil {
-		// step_id = gc.active_work_bead — the logical formula-step id, byte-equal to
-		// manifold.spend.step_id (the usage Fact.StepID source, #3708), so the step->
-		// spend join is exact. NOT gc.step_id.
-		stepID = m["gc.active_work_bead"]
+		// step_id = the work bead's OWN gc.step_id (the logical formula-step). The
+		// session's gc.active_work_bead (= manifold.spend.step_id) is the same step
+		// for the active bead, so the step->spend join is exact. Work beads carry
+		// gc.step_id, never gc.active_work_bead (that lives on the session).
+		stepID = m["gc.step_id"]
+		// run_id = the run-root bead id (gc.root_bead_id) = beadmeta.ResolveRunID with
+		// no workflow_id, so it equals the run_id the spend plane stamps for the run.
+		// Without this the events plane has no run key and no run can open.
+		runID = m["gc.root_bead_id"]
 		// formula = the run's recipe name. Prefer the canonical gc.formula_name (the
 		// producer stamps it on the run-root); fall back to deriving it from the
 		// step bead's gc.step_ref "mol-<formula>.<step>" prefix until that lands.
@@ -66,7 +71,7 @@ func liftContent(payload json.RawMessage) (title, stepID, formula string) {
 			formula = formulaFromStepRef(m["gc.step_ref"])
 		}
 	}
-	return title, stepID, formula
+	return title, stepID, runID, formula
 }
 
 // formulaFromStepRef derives the run formula name from a gc.step_ref of the form
@@ -234,8 +239,8 @@ func (s *sseSource) dispatch(ctx context.Context, city string, data []byte) bool
 	}
 	if s.emitContent {
 		// The ONLY place this axis reads the SSE payload, reached solely under the
-		// content opt-in: lift the bead title + opaque gc.step_id / run-formula.
-		te.Title, te.StepID, te.Formula = liftContent(r.Payload)
+		// content opt-in: lift the bead title + opaque run_id/step_id + run-formula.
+		te.Title, te.StepID, te.RunID, te.Formula = liftContent(r.Payload)
 	}
 	select {
 	case s.events <- te:

--- a/internal/eventsaxis/source.go
+++ b/internal/eventsaxis/source.go
@@ -15,18 +15,67 @@ import (
 	"github.com/gastownhall/gascity/pkg/eventexport"
 )
 
-// rawEvent is the MINIMAL slice of a supervisor SSE event we ever decode. These
-// are the ONLY fields that may cross into a projectable TaggedEvent. Message,
-// Payload, and every other field on the wire are deliberately absent here — the
-// JSON decoder discards them, so free-form content can never be lifted into the
-// envelope. (The supervisor ships run_id/session_id empty in v0; we do not decode
-// them — that is the deferred typed-field follow-up.)
+// rawEvent is the slice of a supervisor SSE event we decode. seq/type/ts/actor/
+// subject are always read. Payload is decoded ONLY when content emission is opted
+// in (Config.EmitContent): liftContent then extracts the bead title + the opaque
+// gc.step_id / run-formula metadata from it. With the opt-in OFF (the default) the
+// payload is ignored and no free-form content is lifted — the envelope-only
+// contract holds. (run_id/session_id ship empty in v0; we do not decode them.)
 type rawEvent struct {
-	Seq     uint64 `json:"seq"`
-	Type    string `json:"type"`
-	TS      string `json:"ts"`
-	Actor   string `json:"actor"`
-	Subject string `json:"subject"`
+	Seq     uint64          `json:"seq"`
+	Type    string          `json:"type"`
+	TS      string          `json:"ts"`
+	Actor   string          `json:"actor"`
+	Subject string          `json:"subject"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// beadPayload is the minimal slice of a bead.* event payload read under the
+// content opt-in: the human title and the gc.* step/formula metadata.
+type beadPayload struct {
+	Bead struct {
+		Title    string            `json:"title"`
+		Metadata map[string]string `json:"metadata"`
+	} `json:"bead"`
+}
+
+// liftContent extracts the opt-in content/correlation fields from a bead.* event
+// payload: the bead title, the opaque gc.step_id, and the run formula name
+// (gc.formula_name, else derived from the gc.step_ref "mol-<formula>.<step>"
+// prefix). Best-effort: a malformed or absent payload yields empties, never an
+// error — a bad payload must never wedge the stream. This is the ONLY place the
+// axis reads the SSE payload, reached solely when Config.EmitContent is set.
+func liftContent(payload json.RawMessage) (title, stepID, formula string) {
+	if len(payload) == 0 {
+		return "", "", ""
+	}
+	var bp beadPayload
+	if err := json.Unmarshal(payload, &bp); err != nil {
+		return "", "", ""
+	}
+	title = bp.Bead.Title
+	if m := bp.Bead.Metadata; m != nil {
+		stepID = m["gc.step_id"]
+		if formula = m["gc.formula_name"]; formula == "" {
+			formula = formulaFromStepRef(m["gc.step_ref"])
+		}
+	}
+	return title, stepID, formula
+}
+
+// formulaFromStepRef derives the run formula name from a gc.step_ref of the form
+// "mol-<formula>.<step>" (e.g. "mol-randy-triage-patrol.apply" -> "randy-triage-patrol").
+// Returns "" when the ref is not in that shape.
+func formulaFromStepRef(ref string) string {
+	const pfx = "mol-"
+	if !strings.HasPrefix(ref, pfx) {
+		return ""
+	}
+	rest := ref[len(pfx):]
+	if i := strings.IndexByte(rest, '.'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
 }
 
 // sseSource implements eventexport.Source. It tails one supervisor SSE stream per
@@ -35,11 +84,12 @@ type rawEvent struct {
 // independently with capped backoff and resumes from its last-acked cursor via the
 // after_seq query param + Last-Event-ID header.
 type sseSource struct {
-	supervisor string
-	cities     []string
-	client     *http.Client
-	cursors    map[string]uint64 // city -> resume seq (last acked)
-	logf       func(format string, args ...any)
+	supervisor  string
+	cities      []string
+	client      *http.Client
+	cursors     map[string]uint64 // city -> resume seq (last acked)
+	logf        func(format string, args ...any)
+	emitContent bool // when true, lift bead title + gc.* step/formula off the payload
 
 	events chan eventexport.TaggedEvent
 }
@@ -52,12 +102,13 @@ func newSSESource(ctx context.Context, cfg Config, client *http.Client, cursors 
 		logf = func(string, ...any) {}
 	}
 	s := &sseSource{
-		supervisor: cfg.Supervisor,
-		cities:     append([]string(nil), cfg.Cities...),
-		client:     client,
-		cursors:    cursors,
-		logf:       logf,
-		events:     make(chan eventexport.TaggedEvent, 256),
+		supervisor:  cfg.Supervisor,
+		cities:      append([]string(nil), cfg.Cities...),
+		client:      client,
+		cursors:     cursors,
+		logf:        logf,
+		emitContent: cfg.EmitContent,
+		events:      make(chan eventexport.TaggedEvent, 256),
 	}
 	go s.run(ctx)
 	return s
@@ -155,9 +206,10 @@ func (s *sseSource) streamOnce(ctx context.Context, city string) error {
 	return sc.Err()
 }
 
-// dispatch decodes one SSE `data:` payload into a TaggedEvent — mapping ONLY the
-// typed primitive fields, never Message/Payload — and hands it to the exporter. It
-// returns false only when ctx is cancelled (the source is shutting down). A
+// dispatch decodes one SSE `data:` payload into a TaggedEvent — mapping the typed
+// primitive fields, plus (only under the EmitContent opt-in) the bead title +
+// gc.step_id/run-formula lifted from the payload via liftContent — and hands it to
+// the exporter. It returns false only when ctx is cancelled (shutting down). A
 // payload that fails to parse, or whose ts is unparseable, is dropped quietly: the
 // projector would reject it anyway, and a malformed line must not kill the stream.
 func (s *sseSource) dispatch(ctx context.Context, city string, data []byte) bool {
@@ -173,6 +225,11 @@ func (s *sseSource) dispatch(ctx context.Context, city string, data []byte) bool
 		Actor:   r.Actor,
 		Subject: r.Subject,
 		// RunID/SessionID intentionally left empty in v0.
+	}
+	if s.emitContent {
+		// The ONLY place this axis reads the SSE payload, reached solely under the
+		// content opt-in: lift the bead title + opaque gc.step_id / run-formula.
+		te.Title, te.StepID, te.Formula = liftContent(r.Payload)
 	}
 	select {
 	case s.events <- te:

--- a/internal/usageaxis/fileid_other.go
+++ b/internal/usageaxis/fileid_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package usageaxis
+
+import "os"
+
+// fileID has no portable inode on non-unix platforms; rotation detection there falls
+// back to the size<offset truncation check.
+func fileID(os.FileInfo) (uint64, bool) { return 0, false }

--- a/internal/usageaxis/fileid_unix.go
+++ b/internal/usageaxis/fileid_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package usageaxis
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileID returns the ledger's inode as a stable filesystem identity. A new inode
+// (rename-and-recreate, or a fresh file at the same path) means the ledger rotated,
+// which the byte-offset check alone cannot see. Returns ok=false if the platform's
+// FileInfo carries no inode.
+func fileID(fi os.FileInfo) (uint64, bool) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return uint64(st.Ino), true
+	}
+	return 0, false
+}

--- a/internal/usageaxis/runner.go
+++ b/internal/usageaxis/runner.go
@@ -1,0 +1,210 @@
+package usageaxis
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Logf is an injectable structured logger; it MUST NOT be called with the token
+// value. The axis upholds that contract.
+type Logf func(format string, args ...any)
+
+const postTimeout = 30 * time.Second
+
+// postResult is the outcome of one batch POST.
+type postResult struct {
+	advance   bool // 2xx: commit the cursor
+	retryable bool // back off and retry (the cursor is NOT advanced)
+}
+
+// Runner owns the usage axis: it tails the ledger, batches, and POSTs to
+// usage-ingest, persisting the per-source resume cursor only on a confirmed POST.
+// Construct it with NewRunner.
+type Runner struct {
+	cfg        Config
+	log        Logf
+	postClient *http.Client
+
+	// seams for tests
+	tail func(path string, cur Cursor, max int) ([]Fact, Cursor, bool, error)
+	post func(ctx context.Context, b Batch) postResult
+}
+
+// NewRunner constructs a Runner. The HTTP client is built ONLY when the axis is
+// Enabled() — a disabled axis never constructs a client or dials. log may be nil.
+func NewRunner(cfg Config, log Logf) *Runner {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	r := &Runner{cfg: cfg, log: log, tail: Tail}
+	if cfg.Enabled() {
+		r.postClient = newPostClient()
+	}
+	r.post = r.httpPost
+	return r
+}
+
+// newPostClient builds the bounded-timeout POST client: refuses ALL redirects so the
+// bearer can't bounce to another host, pins a TLS 1.2 floor (verification stays on),
+// and carries a timeout so a hung ingest endpoint can't wedge the loop.
+func newPostClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   postTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// Run drains the ledger to usage-ingest on each BatchInterval tick until ctx is
+// cancelled, persisting the resume cursor after every confirmed POST. A disabled
+// axis returns immediately (it never dials). With once=true it does a single drain
+// pass and returns (cron / test mode).
+func (r *Runner) Run(ctx context.Context) error { return r.run(ctx, false) }
+
+// RunOnce does a single drain pass (catch up to EOF) and returns.
+func (r *Runner) RunOnce(ctx context.Context) error { return r.run(ctx, true) }
+
+func (r *Runner) run(ctx context.Context, once bool) error {
+	if !r.cfg.Enabled() {
+		r.log("usage: idle — GASWORKS_USAGE_INGEST_URL / _SOURCE_ID / _LEDGER / token not all set (opt in to enable)")
+		return nil
+	}
+	if !URLOK(r.cfg.URL, r.cfg.AllowHTTP) {
+		return fmt.Errorf("usage: GASWORKS_USAGE_INGEST_URL must be https:// (or localhost http with GASWORKS_USAGE_ALLOW_HTTP=1)")
+	}
+
+	st, _ := LoadState(r.cfg.StatePath)
+	cur, ok := st.Get(r.cfg.SourceID)
+	if !ok || cur.NextSeq == 0 {
+		cur = Cursor{Offset: cur.Offset, NextSeq: 1} // 1-based seq for a fresh source
+	}
+
+	r.log("usage: start source=%s ledger=%s interval=%s", r.cfg.SourceID, r.cfg.Ledger, r.cfg.BatchInterval)
+
+	drain := func() {
+		cur = r.drain(ctx, cur, st)
+	}
+
+	drain() // catch up immediately on start
+	if once {
+		return nil
+	}
+
+	t := time.NewTicker(r.cfg.BatchInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.log("usage: stopped")
+			return nil
+		case <-t.C:
+			drain()
+		}
+	}
+}
+
+// drain tails+POSTs repeated batches until caught up (no new facts) or a POST asks to
+// back off, persisting the cursor after each confirmed batch. It returns the latest
+// committed cursor. Bounded by maxBatchesPerDrain so one tick can't hog forever.
+const maxBatchesPerDrain = 50
+
+func (r *Runner) drain(ctx context.Context, cur Cursor, st *State) Cursor {
+	for i := 0; i < maxBatchesPerDrain; i++ {
+		if ctx.Err() != nil {
+			return cur
+		}
+		facts, next, rotated, err := r.tail(r.cfg.Ledger, cur, r.cfg.BatchMax)
+		if err != nil {
+			r.log("usage: tail error: %v", err)
+			return cur
+		}
+		if rotated {
+			r.log("usage: ledger rotated/truncated; resuming from the top (seq stays monotonic)")
+		}
+		if len(facts) == 0 {
+			// No facts, but the offset may have advanced past skipped lines — commit it
+			// so we don't re-scan them forever.
+			if next.Offset != cur.Offset {
+				r.commit(st, next)
+				cur = next
+			}
+			return cur
+		}
+		res := r.post(ctx, Batch{SourceID: r.cfg.SourceID, SchemaVersion: SchemaVersion, Facts: facts})
+		if !res.advance {
+			if res.retryable {
+				r.log("usage: POST not accepted (%d facts held; cursor unchanged, will retry)", len(facts))
+			}
+			return cur // do NOT advance: the same facts/seqs re-POST next time (idempotent)
+		}
+		r.commit(st, next)
+		cur = next
+	}
+	return cur
+}
+
+// commit persists the cursor for this source, logging (never failing) on a write
+// error so a transient disk problem never crashes the axis.
+func (r *Runner) commit(st *State, cur Cursor) {
+	st.Put(r.cfg.SourceID, cur)
+	if err := SaveState(r.cfg.StatePath, st); err != nil {
+		r.log("usage: cursor save failed: %v", err)
+	}
+}
+
+// httpPost POSTs one batch to usage-ingest with the usage bearer and classifies the
+// response into advance / retryable.
+func (r *Runner) httpPost(ctx context.Context, b Batch) postResult {
+	token, err := r.cfg.Token.Token()
+	if err != nil {
+		r.log("usage: token unavailable: %v", err)
+		return postResult{retryable: true}
+	}
+	if token == "" {
+		// An empty token (e.g. a not-yet-populated token file) would POST a bare
+		// "Authorization: Bearer " and 401. Idle this cycle instead and hold the
+		// cursor, so a later credential rotation enables the axis without data loss.
+		r.log("usage: token empty; idling this cycle (cursor held)")
+		return postResult{retryable: true}
+	}
+	body, err := json.Marshal(b)
+	if err != nil {
+		r.log("usage: batch marshal failed: %v", err) // not retryable, but should never happen
+		return postResult{}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return postResult{retryable: true}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := r.postClient.Do(req)
+	if err != nil {
+		r.log("usage: POST error: %v", err)
+		return postResult{retryable: true}
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	switch {
+	case resp.StatusCode/100 == 2:
+		return postResult{advance: true}
+	case resp.StatusCode == 429 || resp.StatusCode/100 == 5:
+		return postResult{retryable: true} // transient: hold the cursor, retry
+	default:
+		// 4xx (schema mismatch, auth, conflict): the batch won't succeed as-is. Hold
+		// the cursor and back off rather than skip — losing data is worse than a loud
+		// retry the operator can see and fix (e.g. a deploy-skew SchemaVersion).
+		r.log("usage: POST rejected %d (holding cursor; check token/schema/edge)", resp.StatusCode)
+		return postResult{retryable: true}
+	}
+}

--- a/internal/usageaxis/runner_test.go
+++ b/internal/usageaxis/runner_test.go
@@ -1,0 +1,116 @@
+package usageaxis
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gascity/gasworks/internal/saauth"
+)
+
+func testCfg(t *testing.T, ledger string) Config {
+	t.Helper()
+	return Config{
+		URL:           "https://usage-ingest.example/v0/usage-ingest",
+		SourceID:      "city-1",
+		Ledger:        ledger,
+		Token:         saauth.EnvProvider("tok"),
+		StatePath:     filepath.Join(t.TempDir(), "cursors.json"),
+		BatchMax:      100,
+		BatchInterval: time.Hour, // irrelevant: tests drive RunOnce
+	}
+}
+
+// fakePoster records the batches it received and returns a scripted result.
+type fakePoster struct {
+	mu      sync.Mutex
+	batches []Batch
+	result  postResult
+}
+
+func (f *fakePoster) post(_ context.Context, b Batch) postResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.batches = append(f.batches, b)
+	return f.result
+}
+
+func TestRunOnceForwardsAndCommitsCursor(t *testing.T) {
+	ledger := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+
+	if err := r.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fp.batches) != 1 || len(fp.batches[0].Facts) != 2 {
+		t.Fatalf("want one batch of 2 facts, got %+v", fp.batches)
+	}
+	if fp.batches[0].SourceID != "city-1" || fp.batches[0].SchemaVersion != SchemaVersion {
+		t.Fatalf("batch envelope wrong: %+v", fp.batches[0])
+	}
+	if fp.batches[0].Facts[0].Seq != 1 || fp.batches[0].Facts[1].Seq != 2 {
+		t.Fatalf("seq must be 1-based monotonic: %+v", fp.batches[0].Facts)
+	}
+	// Cursor persisted at EOF / NextSeq 3.
+	st, _ := LoadState(cfg.StatePath)
+	cur, ok := st.Get("city-1")
+	if !ok || cur.NextSeq != 3 {
+		t.Fatalf("cursor not committed: %+v ok=%v", cur, ok)
+	}
+}
+
+func TestRetryableHoldsCursorAndReplays(t *testing.T) {
+	ledger := writeLedger(t, factLine("r1", "m"))
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{retryable: true}} // POST fails: hold cursor
+	r.post = fp.post
+
+	_ = r.RunOnce(context.Background())
+	// Cursor must NOT be committed.
+	st, _ := LoadState(cfg.StatePath)
+	if _, ok := st.Get("city-1"); ok {
+		t.Fatal("a failed POST must not commit the cursor")
+	}
+	// Next pass succeeds -> the SAME fact (seq 1) is re-POSTed (idempotent replay).
+	fp.result = postResult{advance: true}
+	_ = r.RunOnce(context.Background())
+	last := fp.batches[len(fp.batches)-1]
+	if len(last.Facts) != 1 || last.Facts[0].Seq != 1 {
+		t.Fatalf("replay must re-send the same fact/seq: %+v", last.Facts)
+	}
+}
+
+func TestRunOnceNoFactsNoBatch(t *testing.T) {
+	ledger := writeLedger(t, "") // empty ledger
+	cfg := testCfg(t, ledger)
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+	_ = r.RunOnce(context.Background())
+	if len(fp.batches) != 0 {
+		t.Fatalf("empty ledger must POST nothing, got %d batches", len(fp.batches))
+	}
+}
+
+func TestDisabledAxisIsIdle(t *testing.T) {
+	cfg := testCfg(t, writeLedger(t, factLine("r1", "m")))
+	cfg.URL = "" // disable: egress gate closed
+	if cfg.Enabled() {
+		t.Fatal("cfg with no URL must be disabled")
+	}
+	r := NewRunner(cfg, nil)
+	fp := &fakePoster{result: postResult{advance: true}}
+	r.post = fp.post
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("disabled axis must return nil, got %v", err)
+	}
+	if len(fp.batches) != 0 {
+		t.Fatal("disabled axis must never POST")
+	}
+}

--- a/internal/usageaxis/source.go
+++ b/internal/usageaxis/source.go
@@ -1,0 +1,110 @@
+package usageaxis
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// maxScanBytes bounds one Tail read so a large backlog is chunked across scans
+// rather than read whole into memory. A single usage.jsonl line is a few hundred
+// bytes, so this holds thousands of facts per scan.
+const maxScanBytes = 8 << 20
+
+// Tail reads new COMPLETE lines from the ledger starting at cur.Offset, parses each
+// into a model Fact, assigns a per-source monotonic seq, and returns the facts to
+// forward plus the ADVANCED cursor. The returned cursor is a CANDIDATE — the caller
+// must commit (persist) it only AFTER a confirmed POST, so a crash before the POST
+// re-reads the same bytes and re-assigns the same seqs (idempotent under the
+// usage-ingest seq high-water-mark), losing nothing.
+//
+// Lines are only forwarded once they are complete (terminated by '\n'); a partial
+// trailing write is left for the next scan. Lines that don't parse, or whose kind is
+// not "model", are skipped — the offset still advances past them, but no seq is
+// consumed (so the seq->fact mapping is stable across replays). On truncation or
+// rotation (size < cur.Offset) the offset resets to 0 while NextSeq is preserved, so
+// the new ledger's facts get fresh seqs that never collide with the old ones.
+//
+// A missing ledger (gc hasn't written one yet) is not an error: it returns no facts
+// and the cursor unchanged (the axis idles until the file appears).
+func Tail(path string, cur Cursor, max int) (facts []Fact, next Cursor, rotated bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, cur, false, nil
+		}
+		return nil, cur, false, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, cur, false, err
+	}
+	size := st.Size()
+	id, haveID := fileID(st)
+
+	off := cur.Offset
+	// Rotation: the ledger's filesystem identity changed (rename-and-recreate — a new
+	// file the size check alone would miss because it may already be larger than the
+	// stale offset), OR it shrank below the offset (truncate / copytruncate). Either
+	// way re-read from the top and KEEP NextSeq so seqs stay globally monotonic.
+	if (haveID && cur.FileID != 0 && id != cur.FileID) || size < off {
+		off = 0
+		rotated = true
+	}
+	// The committed FileID always tracks the file we are reading now.
+	newID := cur.FileID
+	if haveID {
+		newID = id
+	}
+	if off >= size {
+		return nil, Cursor{Offset: off, NextSeq: cur.NextSeq, FileID: newID}, rotated, nil // nothing new
+	}
+
+	window := size - off
+	if window > maxScanBytes {
+		window = maxScanBytes
+	}
+	buf := make([]byte, window)
+	if _, err := f.ReadAt(buf, off); err != nil && err != io.EOF {
+		return nil, cur, rotated, err
+	}
+
+	seq := cur.NextSeq
+	if seq == 0 {
+		seq = 1 // seq is 1-based: usage-ingest rejects seq 0
+	}
+	consumed := 0
+	if max < 1 {
+		max = 1
+	}
+	for len(facts) < max {
+		nl := bytes.IndexByte(buf[consumed:], '\n')
+		if nl < 0 {
+			break // no more complete lines in this window
+		}
+		line := bytes.TrimSpace(buf[consumed : consumed+nl])
+		consumed += nl + 1 // step past the '\n'
+		if len(line) == 0 {
+			continue // blank line: skip, offset already advanced
+		}
+		var fct Fact
+		if json.Unmarshal(line, &fct) != nil || fct.Kind != KindModel {
+			continue // unparseable or non-model: drop, no seq consumed
+		}
+		fct.Seq = seq
+		seq++
+		facts = append(facts, fct)
+	}
+
+	// Stall guard: a single line longer than the whole window (no '\n' found while the
+	// window is the full maxScanBytes cap) would never make progress. Skip the
+	// oversized fragment by advancing past the window so the tail keeps moving.
+	if consumed == 0 && window == maxScanBytes {
+		consumed = len(buf)
+	}
+
+	return facts, Cursor{Offset: off + int64(consumed), NextSeq: seq, FileID: newID}, rotated, nil
+}

--- a/internal/usageaxis/source_test.go
+++ b/internal/usageaxis/source_test.go
@@ -1,0 +1,199 @@
+package usageaxis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeLedger writes raw bytes to a temp ledger and returns its path.
+func writeLedger(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "usage.jsonl")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func appendLedger(t *testing.T, path, content string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func factLine(runID, model string) string {
+	b, _ := json.Marshal(map[string]any{
+		"run_id": runID, "session_id": "s", "kind": "model", "model": model,
+		"provider": "anthropic", "input_tokens": 10, "output_tokens": 5,
+		"cost_usd_estimate": 0.001, "upstream_req_id": runID + "-r", "at": 1_700_000_000_000,
+	})
+	return string(b) + "\n"
+}
+
+func TestTailBasicAssignsMonotonicSeq(t *testing.T) {
+	p := writeLedger(t, factLine("run-1", "m1")+factLine("run-2", "m2"))
+	facts, next, rotated, err := Tail(p, Cursor{}, 100)
+	if err != nil || rotated {
+		t.Fatalf("err=%v rotated=%v", err, rotated)
+	}
+	if len(facts) != 2 {
+		t.Fatalf("want 2 facts, got %d", len(facts))
+	}
+	if facts[0].Seq != 1 || facts[1].Seq != 2 {
+		t.Fatalf("seq must be 1-based monotonic: %d, %d", facts[0].Seq, facts[1].Seq)
+	}
+	if facts[0].RunID != "run-1" || facts[1].Model != "m2" {
+		t.Fatalf("fields wrong: %+v", facts)
+	}
+	if next.NextSeq != 3 {
+		t.Fatalf("next seq = %d, want 3", next.NextSeq)
+	}
+	fi, _ := os.Stat(p)
+	if next.Offset != fi.Size() {
+		t.Fatalf("offset = %d, want EOF %d", next.Offset, fi.Size())
+	}
+}
+
+func TestTailLeavesPartialTrailingLine(t *testing.T) {
+	// One complete line + a partial (no trailing newline) line.
+	p := writeLedger(t, factLine("run-1", "m1")+`{"run_id":"run-2","kind":"mo`)
+	facts, next, _, _ := Tail(p, Cursor{}, 100)
+	if len(facts) != 1 || facts[0].RunID != "run-1" {
+		t.Fatalf("only the complete line should forward: %+v", facts)
+	}
+	// Offset is at the end of the complete line, NOT EOF (partial left for next scan).
+	if next.Offset != int64(len(factLine("run-1", "m1"))) {
+		t.Fatalf("offset must stop before the partial line, got %d", next.Offset)
+	}
+	// Completing the partial line on the next scan forwards it with the next seq.
+	appendLedger(t, p, `del","kind":"model","model":"m2","provider":"x","upstream_req_id":"r2","at":1700000000000,"session_id":"s"}`+"\n")
+	facts2, _, _, _ := Tail(p, next, 100)
+	if len(facts2) != 1 || facts2[0].Seq != 2 {
+		t.Fatalf("completed line should forward as seq 2: %+v", facts2)
+	}
+}
+
+func TestTailSkipsInvalidAndNonModelButAdvances(t *testing.T) {
+	content := factLine("run-1", "m1") +
+		"not json at all\n" +
+		`{"kind":"compute","wall_seconds":3,"run_id":"r","at":1}` + "\n" +
+		"\n" + // blank
+		factLine("run-2", "m2")
+	facts, next, _, _ := Tail(p_helper(t, content), Cursor{}, 100)
+	if len(facts) != 2 {
+		t.Fatalf("only the 2 model facts forward, got %d: %+v", len(facts), facts)
+	}
+	// seq is consumed only by forwarded facts: 1 and 2 (not skipped over).
+	if facts[0].Seq != 1 || facts[1].Seq != 2 {
+		t.Fatalf("seq must skip non-forwarded lines: %d, %d", facts[0].Seq, facts[1].Seq)
+	}
+	if next.NextSeq != 3 {
+		t.Fatalf("next seq = %d, want 3", next.NextSeq)
+	}
+}
+
+func TestTailRespectsMax(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m")+factLine("r3", "m"))
+	facts, next, _, _ := Tail(p, Cursor{}, 2)
+	if len(facts) != 2 {
+		t.Fatalf("max=2 must cap at 2 facts, got %d", len(facts))
+	}
+	// Next scan from the advanced cursor gets the 3rd with seq 3.
+	facts2, _, _, _ := Tail(p, next, 2)
+	if len(facts2) != 1 || facts2[0].Seq != 3 {
+		t.Fatalf("continuation must yield the 3rd fact as seq 3: %+v", facts2)
+	}
+}
+
+func TestTailReplayIsStable(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	// Tail from the same start cursor twice (a crash before committing the cursor) —
+	// must produce identical facts + seqs so usage-ingest dedups the replay.
+	a, _, _, _ := Tail(p, Cursor{}, 100)
+	b, _, _, _ := Tail(p, Cursor{}, 100)
+	if len(a) != len(b) {
+		t.Fatalf("replay length differs")
+	}
+	for i := range a {
+		if a[i].Seq != b[i].Seq || a[i].RunID != b[i].RunID {
+			t.Fatalf("replay not stable at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestTailRotationResetsOffsetKeepsSeq(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	_, next, _, _ := Tail(p, Cursor{}, 100) // NextSeq now 3, offset at EOF
+	// Rotate: replace the ledger with a fresh, SHORTER one (size < cursor.Offset).
+	if err := os.WriteFile(p, []byte(factLine("r3", "m")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	facts, after, rotated, _ := Tail(p, next, 100)
+	if !rotated {
+		t.Fatal("a shorter ledger than the cursor offset must be detected as rotated")
+	}
+	if len(facts) != 1 || facts[0].RunID != "r3" {
+		t.Fatalf("rotated ledger must re-read from the top: %+v", facts)
+	}
+	// seq continues monotonically (3), never colliding with the old file's 1/2.
+	if facts[0].Seq != 3 || after.NextSeq != 4 {
+		t.Fatalf("seq must stay monotonic across rotation: fact=%d next=%d", facts[0].Seq, after.NextSeq)
+	}
+}
+
+// The must-fix: a rename-and-recreate rotation where the NEW ledger is already
+// LARGER than the prior offset (so size < offset is FALSE) must still be detected by
+// file identity, or the new file's early facts are silently dropped.
+func TestTailRotationByIdentityWhenLargerThanOffset(t *testing.T) {
+	p := writeLedger(t, factLine("r1", "m")+factLine("r2", "m"))
+	_, next, _, _ := Tail(p, Cursor{}, 100) // NextSeq 3, offset at EOF, FileID captured
+	if next.FileID == 0 {
+		t.Skip("no inode identity on this platform; identity rotation detection unavailable")
+	}
+	oldOffset := next.Offset
+	// Rotate the logrotate way: RENAME the old ledger aside (the old inode stays held
+	// by the renamed file) and CREATE a fresh ledger at the path — so the new file is
+	// guaranteed a DIFFERENT inode even though it is LARGER than the old offset.
+	if err := os.Rename(p, p+".1"); err != nil {
+		t.Fatal(err)
+	}
+	bigger := factLine("n1", "m") + factLine("n2", "m") + factLine("n3", "m")
+	if err := os.WriteFile(p, []byte(bigger), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fi, _ := os.Stat(p)
+	if fi.Size() < oldOffset {
+		t.Fatalf("test setup: replacement (%d) must be >= old offset (%d) to exercise identity detection", fi.Size(), oldOffset)
+	}
+	facts, after, rotated, _ := Tail(p, next, 100)
+	if !rotated {
+		t.Fatal("a new-inode ledger larger than the offset must be detected as rotated (size check alone misses it)")
+	}
+	if len(facts) != 3 || facts[0].RunID != "n1" {
+		t.Fatalf("rotated larger ledger must re-read from the top: %+v", facts)
+	}
+	// seq stays monotonic across the rotation: 3, 4, 5 (never colliding with old 1/2).
+	if facts[0].Seq != 3 || facts[2].Seq != 5 || after.NextSeq != 6 {
+		t.Fatalf("seq must stay monotonic across identity rotation: %+v next=%d", facts, after.NextSeq)
+	}
+}
+
+func TestTailMissingLedgerIsIdle(t *testing.T) {
+	facts, next, _, err := Tail(filepath.Join(t.TempDir(), "nope.jsonl"), Cursor{Offset: 5, NextSeq: 2}, 100)
+	if err != nil {
+		t.Fatalf("missing ledger must not error: %v", err)
+	}
+	if len(facts) != 0 || next.Offset != 5 || next.NextSeq != 2 {
+		t.Fatalf("missing ledger must leave the cursor unchanged: %+v", next)
+	}
+}
+
+func p_helper(t *testing.T, content string) string { return writeLedger(t, content) }

--- a/internal/usageaxis/state.go
+++ b/internal/usageaxis/state.go
@@ -1,0 +1,97 @@
+package usageaxis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Cursor is the per-source resume point. Offset is the byte position in the ledger
+// up to which every fact has been confirmed-forwarded. NextSeq is the seq to assign
+// to the NEXT new fact — it is GLOBALLY monotonic per source and NEVER resets, even
+// across a ledger rotation, so usage-ingest's per-(org|source) seq high-water-mark
+// can drop a forwarder replay without dropping a genuinely new fact. FileID is the
+// ledger's filesystem identity (inode on unix; 0 when unsupported) used to detect a
+// rename-and-recreate rotation that a size check alone would miss.
+type Cursor struct {
+	Offset  int64  `json:"offset"`
+	NextSeq uint64 `json:"next_seq"`
+	FileID  uint64 `json:"file_id,omitempty"`
+}
+
+// State maps source_id -> Cursor. One forwarder instance tails one ledger today, but
+// the map shape matches the events cursors.json so multi-source is a later add.
+type State struct {
+	cursors map[string]Cursor
+}
+
+// NewState returns an empty State.
+func NewState() *State { return &State{cursors: map[string]Cursor{}} }
+
+// Get returns the cursor for a source (zero Cursor + false if unseen).
+func (s *State) Get(source string) (Cursor, bool) {
+	c, ok := s.cursors[source]
+	return c, ok
+}
+
+// Put stores the cursor for a source.
+func (s *State) Put(source string, c Cursor) { s.cursors[source] = c }
+
+// LoadState reads the JSON cursor file. A missing or malformed file yields an empty
+// State and a nil error (start from the top of the ledger).
+func LoadState(path string) (*State, error) {
+	st := NewState()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return st, nil
+	}
+	_ = json.Unmarshal(raw, &st.cursors) // malformed => stay empty
+	if st.cursors == nil {
+		st.cursors = map[string]Cursor{}
+	}
+	return st, nil
+}
+
+// SaveState atomically writes the JSON cursor file (temp sibling + rename). The
+// parent dir is 0700 and the temp file 0600 — the cursor file lists no secrets, but
+// keep it owner-only for consistency with the other axes.
+func SaveState(path string, st *State) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(st.cursors))
+	for k := range st.cursors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	ordered := make(map[string]Cursor, len(keys))
+	for _, k := range keys {
+		ordered[k] = st.cursors[k]
+	}
+	data, err := json.Marshal(ordered)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".cursors-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/usageaxis/usageaxis.go
+++ b/internal/usageaxis/usageaxis.go
@@ -1,0 +1,207 @@
+// Package usageaxis is the usage forwarder axis: it tails a Gas City's local
+// usage-fact ledger (.gc/usage.jsonl, written by gc's usage Sink), assigns each
+// fact a per-source monotonic seq, batches them, and POSTs each Batch to the
+// configured usage-ingest URL with the usage bearer. usage-ingest re-validates and
+// projects each fact into a manifold.spend row tagged source='estimated'.
+//
+// WHAT LEAVES THE BOX. Unlike the events axis (envelope-only, payload-stripped),
+// usage facts ARE numbers: tokens and a list-price cost estimate, plus the opaque
+// {run_id, session_id, step_id} correlation tuple and the model/provider labels.
+// There is no free text — no prompt, response, title, or path. This axis maps only
+// the closed set of usage.Fact fields into the wire Fact; anything gc adds that is
+// not one of them is dropped.
+//
+// AXIS ISOLATION. The usage bearer + config is SEPARATE from events' and recall's:
+// its own env set (GASWORKS_USAGE_*), its own saauth.Provider. One axis's token is
+// never usable by another.
+//
+// EGRESS GATE — SAFE BY DEFAULT. The axis is disabled (Enabled()==false) and never
+// constructs an HTTP client or dials unless a destination URL AND a token source AND
+// a source id AND a ledger path are all configured.
+package usageaxis
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gascity/gasworks/internal/saauth"
+)
+
+const (
+	defaultBatchMax     = 1000
+	defaultBatchEvery   = 5 * time.Second
+	minBatchEvery       = time.Second
+	defaultStateSubpath = "usage-forwarder"
+	defaultLedgerName   = "usage.jsonl"
+	// SchemaVersion is stamped on every Batch; usage-ingest rejects a mismatch. It
+	// is the usage wire contract version, independent of the events one.
+	SchemaVersion = 1
+	// KindModel is the only kind this axis forwards. Compute facts (wall-seconds, no
+	// model/tokens) are dropped at the source — usage-ingest would reject them, and
+	// shipping them wastes a round trip.
+	KindModel = "model"
+)
+
+// Fact is one usage fact on the wire: the gc usage.Fact JSON shape plus the
+// forwarder-assigned per-source Seq. Only the fields usage-ingest reads are mapped;
+// gc may carry others (idempotency_key, city, runtime, …) which are dropped.
+type Fact struct {
+	Seq uint64 `json:"seq"`
+
+	RunID     string `json:"run_id"`
+	SessionID string `json:"session_id"`
+	StepID    string `json:"step_id"`
+	Worker    string `json:"worker"`
+
+	Kind     string `json:"kind"`
+	Model    string `json:"model"`
+	Provider string `json:"provider"`
+
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+
+	CostUSDEstimate float64 `json:"cost_usd_estimate"`
+	Unpriced        bool    `json:"unpriced"`
+
+	UpstreamReqID string `json:"upstream_req_id"`
+	At            int64  `json:"at"`
+}
+
+// Batch is one POST body to usage-ingest.
+type Batch struct {
+	SourceID      string `json:"source_id"`
+	SchemaVersion int    `json:"schema_version"`
+	Facts         []Fact `json:"facts"`
+}
+
+// Config is the resolved usage-axis configuration. Build it with ConfigFromEnv.
+type Config struct {
+	// URL is the usage-ingest destination (trailing slash trimmed); "" => idle.
+	URL string
+	// SourceID is the opaque per-deployment id stamped on every Batch and used by
+	// usage-ingest as the dedup namespace. "" => idle.
+	SourceID string
+	// Ledger is the path to the gc usage.jsonl this axis tails.
+	Ledger string
+	// Token is the usage bearer source (file or env). Its OWN provider — never an
+	// events/recall token. Unconfigured => idle.
+	Token saauth.Provider
+	// StatePath is the resume-cursor file.
+	StatePath string
+	// BatchMax is the max facts per POST.
+	BatchMax int
+	// BatchInterval is the max time between POSTs.
+	BatchInterval time.Duration
+	// AllowHTTP opts in to a plain-http (loopback only) ingest URL for dev.
+	AllowHTTP bool
+}
+
+// Enabled is the egress gate: the axis may construct an HTTP client and dial ONLY
+// when a destination URL AND a source id AND a ledger path AND a token source are
+// all configured. When false the axis never builds a client or sends a request.
+func (c Config) Enabled() bool {
+	return c.URL != "" && c.SourceID != "" && c.Ledger != "" && c.Token.Configured()
+}
+
+// ConfigFromEnv builds a Config from GASWORKS_USAGE_* env. The token Provider prefers
+// GASWORKS_USAGE_TOKEN_FILE and falls back to GASWORKS_USAGE_TOKEN (popped from env,
+// dev-only). Returns a non-fatal warning string for the caller to log (never the
+// token value).
+//
+//	GASWORKS_USAGE_INGEST_URL     usage-ingest destination (https; "" => idle)
+//	GASWORKS_USAGE_SOURCE_ID      opaque per-deployment id ("" => idle)
+//	GASWORKS_USAGE_LEDGER         usage.jsonl path (default ~/.gc/usage.jsonl)
+//	GASWORKS_USAGE_TOKEN_FILE     bearer token file (preferred)
+//	GASWORKS_USAGE_TOKEN          bearer token (dev-only, popped from env)
+//	GASWORKS_USAGE_STATE          resume-cursor file (default XDG state dir)
+//	GASWORKS_USAGE_BATCH_MAX      max facts per POST (default 1000)
+//	GASWORKS_USAGE_BATCH_INTERVAL flush interval seconds (default 5)
+//	GASWORKS_USAGE_ALLOW_HTTP     "1" to allow loopback plain-http ingest (dev)
+func ConfigFromEnv() (Config, string) {
+	home, _ := os.UserHomeDir()
+	var warn string
+
+	token := func() saauth.Provider {
+		if fp := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_TOKEN_FILE")); fp != "" {
+			return saauth.FileProvider(fp)
+		}
+		if tok, ok := saauth.TokenFromEnv("GASWORKS_USAGE_TOKEN"); ok {
+			warn = saauth.EnvWarning
+			return saauth.EnvProvider(tok)
+		}
+		return saauth.Provider{}
+	}()
+
+	ledger := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_LEDGER"))
+	if ledger == "" {
+		ledger = filepath.Join(home, ".gc", defaultLedgerName)
+	}
+
+	state := strings.TrimSpace(os.Getenv("GASWORKS_USAGE_STATE"))
+	if state == "" {
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		state = filepath.Join(stateHome, defaultStateSubpath, "cursors.json")
+	}
+
+	return Config{
+		URL:           strings.TrimRight(strings.TrimSpace(os.Getenv("GASWORKS_USAGE_INGEST_URL")), "/"),
+		SourceID:      strings.TrimSpace(os.Getenv("GASWORKS_USAGE_SOURCE_ID")),
+		Ledger:        ledger,
+		Token:         token,
+		StatePath:     state,
+		BatchMax:      envInt("GASWORKS_USAGE_BATCH_MAX", defaultBatchMax),
+		BatchInterval: envInterval("GASWORKS_USAGE_BATCH_INTERVAL", defaultBatchEvery),
+		AllowHTTP:     os.Getenv("GASWORKS_USAGE_ALLOW_HTTP") == "1",
+	}, warn
+}
+
+// URLOK enforces the https-only rule for the ingest destination: https with a host
+// is always allowed; plain http only with AllowHTTP and a loopback host.
+func URLOK(rawURL string, allowHTTP bool) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if u.Scheme == "https" && u.Host != "" {
+		return true
+	}
+	return u.Scheme == "http" && allowHTTP && (host == "localhost" || host == "127.0.0.1" || host == "::1")
+}
+
+func envInt(name string, def int) int {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return def
+	}
+	return n
+}
+
+func envInterval(name string, def time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	d := time.Duration(n) * time.Second
+	if d < minBatchEvery {
+		return minBatchEvery
+	}
+	return d
+}

--- a/vendor/github.com/gastownhall/gascity/pkg/eventexport/exporter.go
+++ b/vendor/github.com/gastownhall/gascity/pkg/eventexport/exporter.go
@@ -27,6 +27,9 @@ type TaggedEvent struct {
 	Subject   string
 	RunID     string
 	SessionID string
+	StepID    string   // opaque acting-work-bead (run step) id; safeRef-gated at projection (EmitCorrelation)
+	Title     string   // FREE-FORM bead title; emitted only under Options.EmitContent
+	Formula   string   // FREE-FORM run formula name; emitted only under Options.EmitContent
 	_         struct{} // force keyed literals; blocks positional field transposition
 }
 
@@ -46,6 +49,8 @@ type Config struct {
 	TokenProvider     func() (string, error)
 	Salt              []byte
 	ExportRef         bool
+	EmitCorrelation   bool // emit opaque run_id/session_id/step_id (default false)
+	EmitContent       bool // emit free-form title/formula (default false; REVERSES envelope-only — opt-in only)
 	Profile           Profile
 	BatchMax          int           // max events per POST (default 1000)
 	BatchInterval     time.Duration // max time between POSTs (default 5s)
@@ -175,9 +180,16 @@ func (e *Exporter) ingest(te TaggedEvent) {
 		return // already processed (resume overlap)
 	}
 	e.high[te.City] = te.Seq
-	// EmitCorrelation stays false in v0: run_id/session_id ship empty until the
-	// typed-at-record-site follow-up lands (then Config gains the toggle).
-	opt := Options{Salt: e.cfg.Salt, ExportRef: e.cfg.ExportRef, Profile: e.cfg.Profile}
+	// Correlation ids (run_id/session_id/step_id) and free-form content
+	// (title/formula) are emitted only when their respective Config toggles are set;
+	// both default false so the projection stays envelope-only unless opted in.
+	opt := Options{
+		Salt:            e.cfg.Salt,
+		ExportRef:       e.cfg.ExportRef,
+		Profile:         e.cfg.Profile,
+		EmitCorrelation: e.cfg.EmitCorrelation,
+		EmitContent:     e.cfg.EmitContent,
+	}
 	env, ok := ProjectEvent(te, opt)
 	if !ok {
 		return

--- a/vendor/github.com/gastownhall/gascity/pkg/eventexport/project.go
+++ b/vendor/github.com/gastownhall/gascity/pkg/eventexport/project.go
@@ -11,6 +11,13 @@
 // or non-allowlisted event type is dropped, and the envelope is a closed struct
 // so a newly-added source field can never escape by default.
 //
+// EXCEPTION (opt-in): two envelope fields — Title and Formula — carry free-form
+// content (a bead's human title; a run's formula name). They are the deliberate
+// reversal of the envelope-only default, emitted ONLY when Options.EmitContent is
+// set (an explicit operator/org content opt-in), length-capped, and never on a
+// mail-reduced type. With EmitContent unset (the default) the projection stays
+// envelope-only and no content leaves the box.
+//
 // The package imports only the standard library. The supervisor-coupled event
 // source (which knows about internal/events) lives in a separate adapter so
 // this package stays a dependency-light, OSS-consumable projection contract.
@@ -51,8 +58,9 @@ const (
 )
 
 const (
-	maxRefLen  = 64 // run_id/session_id/ref over this are DROPPED, not truncated.
-	minSaltLen = 16 // below this the salted actor hash is brute-forceable; fail closed.
+	maxRefLen     = 64  // run_id/session_id/ref over this are DROPPED, not truncated.
+	minSaltLen    = 16  // below this the salted actor hash is brute-forceable; fail closed.
+	maxContentLen = 256 // free-form title/formula over this are DROPPED, not truncated.
 )
 
 // allowedTypes is the default-deny allowlist of exportable event types, keyed by
@@ -127,6 +135,13 @@ type Envelope struct {
 	Ref       string `json:"ref,omitempty"`        // id-regex-gated reference (opaque id/slug only)
 	RunID     string `json:"run_id,omitempty"`     // opaque run-root correlation id (safeRef-gated)
 	SessionID string `json:"session_id,omitempty"` // opaque session correlation id (safeRef-gated)
+	StepID    string `json:"step_id,omitempty"`    // opaque acting-work-bead (run step) id; safeRef-gated, EmitCorrelation
+	// Title/Formula are the DELIBERATE exception to envelope-only: free-form content
+	// (a bead's human title; a run's formula name), gated by Options.EmitContent (an
+	// explicit operator/org content opt-in), length-capped (dropped, not truncated),
+	// and NOT routed through the opaque-id machinery. They ship empty unless EmitContent.
+	Title   string `json:"title,omitempty"`
+	Formula string `json:"formula,omitempty"`
 }
 
 // Batch is one POST body: the events for a single city.
@@ -141,7 +156,8 @@ type Options struct {
 	Salt            []byte  // actor-hash salt; must be >= 16 bytes (ProjectEvent fails closed otherwise)
 	ExportRef       bool    // include the id-gated ref (opaque ids/slugs only)
 	Profile         Profile // redaction profile (default ProfileRedactedEnvelope)
-	EmitCorrelation bool    // emit opaque run_id/session_id; default false (they ship empty in v0)
+	EmitCorrelation bool    // emit opaque run_id/session_id/step_id; default false (they ship empty in v0)
+	EmitContent     bool    // emit free-form Title/Formula; default false. REVERSES the envelope-only default — set ONLY under an explicit operator/org content opt-in.
 }
 
 // ActorHash returns a salted, non-reversible, 16-hex fingerprint of an actor.
@@ -198,6 +214,21 @@ func ProjectEvent(te TaggedEvent, opt Options) (Envelope, bool) {
 		if s := safeRef(te.SessionID); s != "" {
 			env.SessionID = s
 		}
+		if st := safeRef(te.StepID); st != "" {
+			env.StepID = st
+		}
+	}
+	// Content fields are the deliberate exception to the envelope-only default:
+	// gated by EmitContent (NOT the opaque-id machinery), length-capped (dropped,
+	// not truncated), and — via the mailReduced early-return above — never on a
+	// mail-reduced type.
+	if opt.EmitContent {
+		if t := capContent(te.Title); t != "" {
+			env.Title = t
+		}
+		if f := capContent(te.Formula); f != "" {
+			env.Formula = f
+		}
 	}
 	return env, true
 }
@@ -219,7 +250,7 @@ func ValidateEnvelope(env Envelope) error {
 		return fmt.Errorf("eventexport: invalid ts %q", env.TS)
 	}
 	if mailReduced[env.Type] {
-		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" {
+		if env.ActorHash != "" || env.Ref != "" || env.RunID != "" || env.SessionID != "" || env.StepID != "" || env.Title != "" || env.Formula != "" {
 			return fmt.Errorf("eventexport: %q must carry only {seq,type,ts}", env.Type)
 		}
 		return nil
@@ -240,6 +271,17 @@ func ValidateEnvelope(env Envelope) error {
 	}
 	if env.SessionID != "" && !IsOpaqueRef(env.SessionID) {
 		return fmt.Errorf("eventexport: session_id %q is not an opaque id", env.SessionID)
+	}
+	if env.StepID != "" && !IsOpaqueRef(env.StepID) {
+		return fmt.Errorf("eventexport: step_id %q is not an opaque id", env.StepID)
+	}
+	// Title/Formula are free-form content (the EmitContent exception): the wire
+	// invariant is a length bound, NOT opaqueness — charset is unrestricted.
+	if len(env.Title) > maxContentLen {
+		return fmt.Errorf("eventexport: title exceeds %d bytes", maxContentLen)
+	}
+	if len(env.Formula) > maxContentLen {
+		return fmt.Errorf("eventexport: formula exceeds %d bytes", maxContentLen)
 	}
 	return nil
 }
@@ -308,6 +350,17 @@ func safeRef(s string) string {
 	first := s[0]
 	firstAlnum := (first >= 'a' && first <= 'z') || (first >= '0' && first <= '9')
 	if !firstAlnum {
+		return ""
+	}
+	return s
+}
+
+// capContent returns s iff it is non-empty and within the content length bound;
+// an over-cap value is DROPPED (not truncated — a half-string is worse than
+// absent). Unlike safeRef it does NOT restrict the charset: Title/Formula are
+// free text by design (the EmitContent exception to the envelope-only contract).
+func capContent(s string) string {
+	if s == "" || len(s) > maxContentLen {
 		return ""
 	}
 	return s

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/gastownhall/gascity v1.1.1-0.20260623105741-7f39639d10e4
+# github.com/gastownhall/gascity v1.1.1-0.20260625212128-87de14874a96
 ## explicit; go 1.26.4
 github.com/gastownhall/gascity/pkg/eventexport
 # github.com/klauspost/cpuid/v2 v2.3.0


### PR DESCRIPTION
Two layers of event correlation/content, gated independently.

## Envelope-first correlation (Fix B — `run_id`/`session_id`/`step_id`)
The gc supervisor now stamps the resolved `run_id`/`session_id`/`step_id` onto the event-stream **envelope** (Fix A — `beadmeta.ResolveRunID`, never empty). The forwarder reads them **straight off the envelope** in `rawEvent`/`dispatch`. These are opaque, PII-free, system-generated ids → they ride the envelope-only contract and need **no content opt-in**.

- `EmitCorrelation` is **decoupled** from `EmitContent` and gets its own gate (`GASWORKS_EVENTS_EMIT_CORRELATION`, **default true**). The package always tied them *"until a typed-at-record-site source lands"* — that source has now landed. Pre-Fix-A producers send the fields empty, so they emit nothing (no change until the producer ships Fix A).
- `safeRef` in `pkg/eventexport` keeps the ids opaque (lowercase id/slug, ≤64 bytes).

## Content lift (original — `title`/`formula`, opt-in)
Under `EmitContent` (default off; reverses the envelope-only default), `liftContent` lifts the free-form bead **title** + run **formula** off the payload. It also derives `run_id`/`step_id` from the payload metadata (`gc.root_bead_id`/`gc.step_id`) as a **fallback** for producers that predate the envelope fields — the envelope value always wins.

## Result
Every event carries an opaque `run_id` once the producer ships Fix A → the events plane gains a run key and Forge run-detail can group a run, without turning on free-form content.

## Tests
`dispatch` envelope-first / fallback / precedence unit cases; end-to-end through the projection (run_id flows under `EmitCorrelation`, withheld without it, no content leak with `EmitContent` off); `-race` + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)