### PR TITLE
feat(cli): land the gasworks CLI on main (login/getToken/whoami/logout) + OOBE polish

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,0 +1,20 @@
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]"
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -145,3 +145,9 @@ go test ./... -race
 ```
 
 The Go CI (`go-ci.yml`) runs `gofmt -l`, `go build`, `go vet`, `go test -race`, and a GoReleaser snapshot cross-build on every PR. Releases are cut by pushing a `v*` tag, which fires the signed `release.yml` pipeline (merging to `main` does **not** release).
+
+## gasworks CLI (Python)
+
+A small CLI (`src/gasworks/`) for staff/agent credentials: `login` (SSO device/browser,
+DPoP), `getToken <product>` (RFC 8693 → short-lived EIA, cached/auto-refreshed), `whoami`,
+`logout`. Install with `pip install .` (gives the `gasworks` command); tests: `pytest`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gasworks"
+version = "0.1.0"
+description = "gasworks CLI — SSO login + getToken (RFC 8693 EIA minting) for the Gas City credential plane"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Gas City" }]
+keywords = ["sts", "oauth", "dpop", "rfc8693", "eia", "gascity"]
+# DPoP requires ES256 asymmetric signing, which the stdlib cannot do — cryptography is the
+# one and only runtime dependency. HTTP is stdlib urllib (with a custom User-Agent).
+dependencies = ["cryptography>=3.4"]
+
+[project.urls]
+Homepage = "https://github.com/gascity/gasworks"
+Issues = "https://github.com/gascity/gasworks/issues"
+
+[project.scripts]
+gasworks = "gasworks.cli:main"
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/gasworks/__init__.py
+++ b/src/gasworks/__init__.py
@@ -1,0 +1,10 @@
+"""gasworks — SSO login + getToken for the Gas City credential plane.
+
+`gasworks login` authenticates a user against Keycloak SSO (device-code or browser
+loopback, both PKCE) and stores the refresh token + a DPoP key. `gasworks getToken
+<product>` discovers the caller's org + mintable scopes and exchanges the session at
+the STS for a short-lived EIA (RFC 8693). Everything narrows server-side; the client
+never asserts authority it wasn't granted.
+"""
+
+__version__ = "0.1.0"

--- a/src/gasworks/cli.py
+++ b/src/gasworks/cli.py
@@ -1,0 +1,280 @@
+"""gasworks CLI: login, getToken, whoami, logout.
+
+The token lifecycle has three layers, each cached with its own TTL:
+  Keycloak refresh_token -> id_token (refreshed when <60s left; rotation persisted)
+  id_token -> STS session per org (8h; DPoP-bound)
+  session -> EIA per (org, product, scope) (90s; re-minted when <15s left)
+Discovery (`/sts/v0/context`) supplies the concrete org + the exact mintable scopes so the
+strict /login + /token gates can be satisfied without the user guessing.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+from . import config, oidc, store, sts
+from .dpop import DPoPKey
+from .httpc import HTTPError
+from .jwtutil import decode_payload
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _eprint(*a) -> None:
+    print(*a, file=sys.stderr)
+
+
+def _die(msg: str, code: int = 1):
+    _eprint(f"gasworks: {msg}")
+    sys.exit(code)
+
+
+def _token_exp(tok: str) -> int:
+    try:
+        return int(decode_payload(tok).get("exp", 0))
+    except Exception:
+        return 0
+
+
+def _has_display() -> bool:
+    if sys.platform in ("darwin", "win32"):
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _org_list(orgs) -> str:
+    return ", ".join(f"{o.get('slug')}({o['org_id']})" for o in orgs) or "(none)"
+
+
+# --- login ---
+
+def cmd_login(cfg, args):
+    use_device = args.device or (not args.browser and not _has_display())
+    flow = oidc.device_login if use_device else oidc.browser_login
+    try:
+        tok = flow(cfg)
+    except (RuntimeError, HTTPError) as e:
+        _die(str(e))
+    idt = tok.get("id_token")
+    if not idt:
+        _die("login returned no id_token (is the 'openid' scope enabled on the client?)")
+    # Assert the token is OUR client's id_token before trusting it (catches a realm-default change
+    # as a clear client error rather than an opaque STS 401 later).
+    claims = decode_payload(idt)
+    aud = claims.get("aud")
+    aud = aud if isinstance(aud, list) else [aud]
+    if cfg.client_id not in aud or claims.get("azp") not in (cfg.client_id, None):
+        _die(f"the id_token is not for {cfg.client_id} (aud/azp mismatch)")
+    with store.update() as data:
+        data["id_token"] = idt
+        if tok.get("refresh_token"):
+            data["refresh_token"] = tok["refresh_token"]
+        if args.org:
+            data["default_org"] = args.org
+        # a fresh login invalidates any prior STS sessions / cached EIAs
+        data.pop("sessions", None)
+        data.pop("eia_cache", None)
+    who = claims.get("email") or claims.get("preferred_username") or claims.get("sub")
+    print(f"Logged in as {who}.")
+
+
+# --- token lifecycle helpers ---
+
+def _ensure_id_token(cfg):
+    """Return a valid id_token, refreshing (and persisting the rotated refresh token) if needed.
+    Runs in its own locked write so the rotation survives even if a later mint step fails."""
+    with store.update() as data:
+        idt = data.get("id_token")
+        if idt and _token_exp(idt) - _now() > 60:
+            return idt
+        rt = data.get("refresh_token")
+        if not rt:
+            _die("not logged in — run `gasworks login`")
+        try:
+            tok = oidc.refresh(cfg, rt)
+        except HTTPError as e:
+            _die(f"session expired ({e.oauth_error or e.status}) — run `gasworks login` again")
+        data["refresh_token"] = tok.get("refresh_token", rt)  # Keycloak rotates — persist it
+        if tok.get("id_token"):
+            data["id_token"] = tok["id_token"]
+        return data["id_token"]
+
+
+def _pick_org(ctx, requested, data):
+    orgs = ctx.get("orgs", [])
+    ids = [o["org_id"] for o in orgs]
+    if requested:
+        for o in orgs:
+            if requested in (o["org_id"], o.get("slug")):
+                return o["org_id"]
+        _die(f"you are not a member of org '{requested}'. Your orgs: {_org_list(orgs)}")
+    if data.get("default_org") in ids:
+        return data["default_org"]
+    if ctx.get("default_org_id") in ids:
+        return ctx["default_org_id"]
+    if len(orgs) == 1:
+        return orgs[0]["org_id"]
+    if not orgs:
+        _die("no orgs for this account — run `gasworks whoami` to check your account, "
+             "or ask an admin to add you to an org")
+    _die(f"you belong to multiple orgs — pass --org. Your orgs: {_org_list(orgs)}")
+
+
+def _new_session(cfg, data, org, id_token):
+    dpop = DPoPKey.generate()
+    try:
+        res = sts.login(cfg, id_token, org, dpop)
+    except HTTPError as e:
+        if e.status == 403:
+            _die(f"not a member of org {org} ({e.oauth_error})")
+        _die(f"login to org {org} failed: {e}")
+    data.setdefault("sessions", {})[org] = {
+        "session_token": res["session_token"],
+        "dpop_pem": dpop.to_pem(),
+        "expires_at": _now() + int(res.get("expires_in", 28800)),
+    }
+    return res["session_token"], dpop
+
+
+def _ensure_session(cfg, data, org, id_token):
+    sess = data.get("sessions", {}).get(org)
+    if sess and sess.get("expires_at", 0) - _now() > 30:
+        return sess["session_token"], DPoPKey.from_pem(sess["dpop_pem"])
+    return _new_session(cfg, data, org, id_token)
+
+
+def _emit(eia, scope, as_json):
+    if as_json:
+        print(json.dumps({"access_token": eia, "token_type": "DPoP", "expires_in": 90, "scope": scope}))
+    else:
+        print(eia)  # raw EIA, pipeable
+
+
+# --- getToken ---
+
+def cmd_get_token(cfg, args):
+    product = args.product
+    id_token = _ensure_id_token(cfg)
+    try:
+        ctx = sts.context(cfg, id_token, provision=True)
+    except HTTPError as e:
+        _die(f"discovery failed: {e}")
+
+    with store.update() as data:
+        org = _pick_org(ctx, args.org, data)
+        org_ctx = next((o for o in ctx["orgs"] if o["org_id"] == org), None)
+        if org_ctx is None:
+            _die(f"you are not a member of org {org}")
+
+        if args.scope:
+            scope = args.scope
+        else:
+            prod = org_ctx.get("products", {}).get(product)
+            if not prod or not prod.get("scopes"):
+                avail = ", ".join(sorted(org_ctx.get("products", {}).keys())) or "(none)"
+                _die(f"no mintable '{product}' scope for org {org_ctx.get('slug')} "
+                     f"(entitled products: {avail})")
+            scope = " ".join(prod["scopes"])
+
+        cache_key = f"{org}|{product}|{scope}"
+        cached = data.get("eia_cache", {}).get(cache_key)
+        if not args.refresh and cached and cached.get("expires_at", 0) - _now() > 15:
+            _emit(cached["eia"], scope, args.json)
+            return
+
+        session_token, dpop = _ensure_session(cfg, data, org, id_token)
+        try:
+            res = sts.exchange(cfg, session_token, product, scope, dpop)
+        except HTTPError as e:
+            if e.status == 401:  # session not resolvable -> re-establish once and retry
+                session_token, dpop = _new_session(cfg, data, org, id_token)
+                try:
+                    res = sts.exchange(cfg, session_token, product, scope, dpop)
+                except HTTPError as e2:
+                    _die(f"getToken failed: {e2}")
+            elif e.status == 403:
+                _die(f"getToken denied: {e.oauth_error} ({e})")
+            else:
+                _die(f"getToken failed: {e}")
+
+        eia = res["access_token"]
+        data.setdefault("eia_cache", {})[cache_key] = {
+            "eia": eia, "expires_at": _now() + int(res.get("expires_in", 90))
+        }
+        _emit(eia, res.get("scope", scope), args.json)
+
+
+# --- whoami / logout ---
+
+def cmd_whoami(cfg, args):
+    data = store.load()
+    if not data.get("id_token"):
+        _die("not logged in — run `gasworks login`")
+    id_token = _ensure_id_token(cfg)
+    claims = decode_payload(id_token)
+    print(f"subject:  {claims.get('sub')}")
+    print(f"email:    {claims.get('email')}")
+    if claims.get("preferred_username"):
+        print(f"username: {claims.get('preferred_username')}")
+    try:
+        ctx = sts.context(cfg, id_token, provision=False)
+    except HTTPError as e:
+        if e.status == 404:
+            print("orgs:     (no account yet — run `gasworks getToken <product>` to provision one)")
+            return
+        _eprint(f"  (could not list orgs: {e})")
+        return
+    print(f"default org: {ctx.get('default_org_id')}")
+    for o in ctx.get("orgs", []):
+        prods = ", ".join(sorted(o.get("products", {}).keys())) or "(none)"
+        star = " *" if o.get("is_default") else ""
+        print(f"  - {o.get('slug')} ({o.get('org_id')}) role={o.get('role')} products=[{prods}]{star}")
+
+
+def cmd_logout(cfg, args):
+    data = store.load()
+    rt = data.get("refresh_token")
+    if rt:
+        oidc.revoke(cfg, rt)  # best-effort server-side revocation
+    store.clear()
+    print("Logged out.")
+
+
+def main(argv=None) -> int:
+    cfg = config.load()
+    p = argparse.ArgumentParser(prog="gasworks", description="SSO login + getToken (EIA) for Gas City.")
+    sub = p.add_subparsers(dest="cmd")
+
+    lp = sub.add_parser("login", help="authenticate via SSO")
+    lp.add_argument("--device", action="store_true", help="force the device-code flow (headless)")
+    lp.add_argument("--browser", action="store_true", help="force the browser loopback flow")
+    lp.add_argument("--org", help="remember a default org for getToken")
+
+    gp = sub.add_parser("getToken", aliases=["get-token"], help="mint a short-lived EIA for a product")
+    gp.add_argument("product", help="e.g. manifold, crucible")
+    gp.add_argument("--org", help="org id or slug (defaults to your default/sole org)")
+    gp.add_argument("--scope", help="override the discovered scopes (space-separated)")
+    gp.add_argument("--json", action="store_true", help="emit a JSON envelope instead of the raw EIA")
+    gp.add_argument("--refresh", action="store_true", help="bypass the local EIA cache")
+
+    sub.add_parser("whoami", help="show the logged-in identity + orgs")
+    sub.add_parser("logout", help="revoke the refresh token + clear stored credentials")
+
+    args = p.parse_args(argv)
+    if not args.cmd:
+        p.print_help()
+        return 2
+    handler = {
+        "login": cmd_login, "getToken": cmd_get_token, "get-token": cmd_get_token,
+        "whoami": cmd_whoami, "logout": cmd_logout,
+    }[args.cmd]
+    handler(cfg, args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gasworks/config.py
+++ b/src/gasworks/config.py
@@ -1,0 +1,64 @@
+"""Endpoint + client configuration, with GASWORKS_* env overrides for dev/testing."""
+
+import os
+from dataclasses import dataclass
+
+from . import __version__
+
+DEFAULT_STS_BASE = "https://works.gascity.com"
+DEFAULT_OIDC_ISSUER = "https://auth.gascity.com/realms/gascity"
+DEFAULT_CLIENT_ID = "gasworks-cli"
+# Fixed loopback port for the browser auth-code flow. It MUST match a redirect URI
+# registered on the gasworks-cli realm client (Keycloak's `*` does not span the port,
+# so an ephemeral port would not match). The device-code flow needs no redirect URI.
+DEFAULT_LOOPBACK_PORT = 9822
+
+USER_AGENT = f"gasworks-cli/{__version__}"
+
+
+@dataclass(frozen=True)
+class Config:
+    sts_base: str
+    oidc_issuer: str
+    client_id: str
+    loopback_port: int
+
+    # --- STS (works.gascity.com) ---
+    @property
+    def login_url(self) -> str:
+        return f"{self.sts_base}/sts/v0/login"
+
+    @property
+    def token_url(self) -> str:
+        return f"{self.sts_base}/sts/v0/token"
+
+    @property
+    def context_url(self) -> str:
+        return f"{self.sts_base}/sts/v0/context"
+
+    # --- Keycloak (auth.gascity.com) ---
+    @property
+    def device_auth_url(self) -> str:
+        return f"{self.oidc_issuer}/protocol/openid-connect/auth/device"
+
+    @property
+    def authorize_url(self) -> str:
+        return f"{self.oidc_issuer}/protocol/openid-connect/auth"
+
+    @property
+    def oidc_token_url(self) -> str:
+        return f"{self.oidc_issuer}/protocol/openid-connect/token"
+
+    @property
+    def revoke_url(self) -> str:
+        return f"{self.oidc_issuer}/protocol/openid-connect/revoke"
+
+
+def load() -> Config:
+    """Build Config from defaults + GASWORKS_* env overrides."""
+    return Config(
+        sts_base=os.environ.get("GASWORKS_STS_URL", DEFAULT_STS_BASE).rstrip("/"),
+        oidc_issuer=os.environ.get("GASWORKS_OIDC_ISSUER", DEFAULT_OIDC_ISSUER).rstrip("/"),
+        client_id=os.environ.get("GASWORKS_CLIENT_ID", DEFAULT_CLIENT_ID),
+        loopback_port=int(os.environ.get("GASWORKS_LOOPBACK_PORT", DEFAULT_LOOPBACK_PORT)),
+    )

--- a/src/gasworks/dpop.py
+++ b/src/gasworks/dpop.py
@@ -1,0 +1,78 @@
+"""RFC 9449 DPoP proofs over an EC P-256 (ES256) key, plus the RFC 7638 thumbprint.
+
+Two server invariants are enforced here:
+  * golang-jwt ES256 requires the JWS signature to be exactly 64 raw bytes (r||s, 32 each),
+    NOT the DER `cryptography` emits — so we convert.
+  * the STS re-derives the jkt over fixed 32-byte big-endian coordinates and pins it across
+    /login and /token — so we emit fixed-width 32-byte coords and reuse ONE key per session.
+Every proof gets a fresh jti + iat; proofs are never reused.
+"""
+
+import hashlib
+import json
+import time
+import uuid
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+from .jwtutil import b64url_encode
+
+
+def _coord(n: int) -> str:
+    """A P-256 coordinate as 32-byte big-endian, base64url no padding (the jkt input)."""
+    return b64url_encode(n.to_bytes(32, "big"))
+
+
+class DPoPKey:
+    """A session DPoP key. Generate once per STS session; reuse across login + token."""
+
+    def __init__(self, key: ec.EllipticCurvePrivateKey):
+        self._key = key
+
+    @classmethod
+    def generate(cls) -> "DPoPKey":
+        return cls(ec.generate_private_key(ec.SECP256R1()))
+
+    @classmethod
+    def from_pem(cls, pem: str) -> "DPoPKey":
+        return cls(serialization.load_pem_private_key(pem.encode("ascii"), password=None))
+
+    def to_pem(self) -> str:
+        return self._key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode("ascii")
+
+    def public_jwk(self) -> dict:
+        """The PUBLIC EC JWK embedded in the proof header (never the private `d`)."""
+        nums = self._key.public_key().public_numbers()
+        return {"kty": "EC", "crv": "P-256", "x": _coord(nums.x), "y": _coord(nums.y)}
+
+    def thumbprint(self) -> str:
+        """RFC 7638 jkt: base64url(SHA-256(canonical JWK)). For display/debug; the STS
+        re-derives its own from the proof's jwk and matches the session against itself."""
+        jwk = self.public_jwk()  # exactly the 4 required EC members
+        canon = json.dumps(jwk, sort_keys=True, separators=(",", ":"))
+        return b64url_encode(hashlib.sha256(canon.encode("ascii")).digest())
+
+    def _es256(self, signing_input: bytes) -> bytes:
+        der = self._key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+        r, s = decode_dss_signature(der)
+        return r.to_bytes(32, "big") + s.to_bytes(32, "big")  # raw 64-byte JWS ES256
+
+    def proof(self, htm: str, htu: str) -> str:
+        """A fresh DPoP proof JWT for one request. `htu` must be the exact STS URL."""
+        header = {"typ": "dpop+jwt", "alg": "ES256", "jwk": self.public_jwk()}
+        payload = {
+            "htm": htm.upper(),
+            "htu": htu,
+            "iat": int(time.time()),
+            "jti": uuid.uuid4().hex,
+        }
+        h = b64url_encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+        p = b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        sig = b64url_encode(self._es256(f"{h}.{p}".encode("ascii")))
+        return f"{h}.{p}.{sig}"

--- a/src/gasworks/httpc.py
+++ b/src/gasworks/httpc.py
@@ -1,0 +1,68 @@
+"""Thin urllib wrapper: a custom User-Agent on every request (Keycloak/Cloudflare returns
+1010 to the default Python UA), TLS verification always on, form/GET helpers, and a typed
+HTTPError carrying the parsed body for OAuth/STS error mapping.
+
+Named `httpc` (not `http`) so it never shadows the stdlib `http` package.
+"""
+
+import json
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+from .config import USER_AGENT
+
+_TLS = ssl.create_default_context()  # verifies certs — never disabled
+
+
+class HTTPError(Exception):
+    def __init__(self, status: int, body: Any, url: str):
+        self.status = status
+        self.body = body  # parsed dict when JSON, else str
+        self.url = url
+        err = body.get("error") if isinstance(body, dict) else None
+        desc = body.get("error_description") if isinstance(body, dict) else None
+        detail = desc or (body if isinstance(body, str) else "")
+        super().__init__(f"{status} {err or ''} {detail}".strip())
+
+    @property
+    def oauth_error(self) -> Optional[str]:
+        return self.body.get("error") if isinstance(self.body, dict) else None
+
+
+def _parse(raw: str) -> Any:
+    raw = raw.strip()
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _request(method: str, url: str, *, data: Optional[bytes] = None,
+             headers: Optional[Dict[str, str]] = None, timeout: int = 30) -> Tuple[int, Any]:
+    h = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, data=data, headers=h, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_TLS) as resp:
+            return resp.status, _parse(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raise HTTPError(e.code, _parse(e.read().decode("utf-8", "replace")), url) from None
+
+
+def post_form(url: str, form: Dict[str, str], headers: Optional[Dict[str, str]] = None,
+              timeout: int = 30) -> Tuple[int, Any]:
+    h = {"Content-Type": "application/x-www-form-urlencoded"}
+    if headers:
+        h.update(headers)
+    return _request("POST", url, data=urllib.parse.urlencode(form).encode("utf-8"),
+                    headers=h, timeout=timeout)
+
+
+def get(url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 30) -> Tuple[int, Any]:
+    return _request("GET", url, headers=headers, timeout=timeout)

--- a/src/gasworks/jwtutil.py
+++ b/src/gasworks/jwtutil.py
@@ -1,0 +1,36 @@
+"""Minimal JWT helpers: base64url + UNVERIFIED payload/header decode.
+
+The CLI never verifies a JWT signature itself — the STS verifies the subject_token and
+products verify the EIA offline. These helpers are only for reading claims (whoami, the
+id_token aud/azp assertion, expiry checks) and for building DPoP proofs.
+"""
+
+import base64
+import json
+from typing import Any, Dict
+
+
+def b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def b64url_encode(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _segment(token: str, idx: int) -> Dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        raise ValueError("not a JWT")
+    return json.loads(b64url_decode(parts[idx]))
+
+
+def decode_header(token: str) -> Dict[str, Any]:
+    """Decode a JWT header WITHOUT verifying the signature."""
+    return _segment(token, 0)
+
+
+def decode_payload(token: str) -> Dict[str, Any]:
+    """Decode a JWT payload WITHOUT verifying the signature."""
+    return _segment(token, 1)

--- a/src/gasworks/oidc.py
+++ b/src/gasworks/oidc.py
@@ -1,0 +1,162 @@
+"""Keycloak OIDC: device-code and browser auth-code (both PKCE), refresh, and revoke.
+
+Every grant requests scope='openid ...' — `openid` is NOT a default client scope, and without
+it Keycloak returns only an access_token and no id_token (the STS subject_token). `offline_access`
+asks for a durable refresh token. Keycloak rotates refresh tokens on use, so the caller MUST
+persist the newly-returned one.
+"""
+
+import base64
+import hashlib
+import http.server
+import os
+import secrets
+import time
+import urllib.parse
+import webbrowser
+from typing import Callable, Dict
+
+from . import httpc
+from .config import Config
+from .jwtutil import decode_payload
+
+OIDC_SCOPE = "openid profile email offline_access"
+
+
+def _pkce():
+    verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode("ascii")
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def device_login(cfg: Config, print_fn: Callable[[str], None] = print) -> Dict:
+    """Device-authorization grant (headless). Returns the token response (id_token, refresh_token...)."""
+    verifier, challenge = _pkce()
+    _, body = httpc.post_form(cfg.device_auth_url, {
+        "client_id": cfg.client_id,
+        "scope": OIDC_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    })
+    device_code = body["device_code"]
+    interval = int(body.get("interval", 5))
+    deadline = time.time() + int(body.get("expires_in", 600))
+    uri = body.get("verification_uri_complete") or body.get("verification_uri")
+    code = body.get("user_code")
+    print_fn("")
+    print_fn("Sign in to Gas City to continue:")
+    print_fn("")
+    print_fn(f"  1. Open:  {uri}")
+    if code and not body.get("verification_uri_complete"):
+        print_fn(f"  2. Enter code:  {code}")
+    print_fn("")
+    print_fn("Waiting for you to authorize... (Ctrl-C to cancel)")
+    while time.time() < deadline:
+        time.sleep(max(interval, 1))
+        try:
+            _, tok = httpc.post_form(cfg.oidc_token_url, {
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": cfg.client_id,
+                "code_verifier": verifier,
+            })
+            return tok
+        except httpc.HTTPError as e:
+            err = e.oauth_error
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                interval += 5
+                continue
+            if err in ("expired_token", "access_denied"):
+                raise RuntimeError(f"device login failed: {err}") from None
+            raise
+    raise RuntimeError("device login timed out")
+
+
+def browser_login(cfg: Config, print_fn: Callable[[str], None] = print) -> Dict:
+    """Authorization-code + PKCE on a 127.0.0.1 loopback. The fixed port must be a registered
+    redirect URI on the gasworks-cli client (Keycloak's `*` does not span the port)."""
+    verifier, challenge = _pkce()
+    state = secrets.token_urlsafe(24)
+    nonce = secrets.token_urlsafe(24)
+    redirect_uri = f"http://127.0.0.1:{cfg.loopback_port}/callback"
+    auth_url = cfg.authorize_url + "?" + urllib.parse.urlencode({
+        "client_id": cfg.client_id, "response_type": "code", "redirect_uri": redirect_uri,
+        "scope": OIDC_SCOPE, "state": state, "nonce": nonce,
+        "code_challenge": challenge, "code_challenge_method": "S256",
+    })
+
+    box: Dict[str, str] = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *a):  # silence
+            pass
+
+        def do_GET(self):
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+            q = urllib.parse.parse_qs(parsed.query)
+            box["code"] = (q.get("code") or [""])[0]
+            box["state"] = (q.get("state") or [""])[0]
+            box["error"] = (q.get("error") or [""])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"<html><body><h3>gasworks: signed in. You can close this tab.</h3></body></html>")
+
+    try:
+        # bind 127.0.0.1 ONLY (never 0.0.0.0)
+        httpd = http.server.HTTPServer(("127.0.0.1", cfg.loopback_port), Handler)
+    except OSError as e:
+        raise RuntimeError(
+            f"loopback port {cfg.loopback_port} is busy ({e}); free it or use --device"
+        ) from None
+    httpd.timeout = 300
+    print_fn(f"\nOpening your browser to sign in...\nIf it doesn't open, visit:\n\n    {auth_url}\n")
+    try:
+        webbrowser.open(auth_url)
+    except Exception:
+        pass
+    try:
+        httpd.handle_request()  # serve exactly one callback, or time out
+    finally:
+        httpd.server_close()
+
+    if box.get("error"):
+        raise RuntimeError(f"login failed: {box['error']}")
+    if not box.get("code"):
+        raise RuntimeError("login timed out waiting for the browser callback")
+    if box.get("state") != state:
+        raise RuntimeError("state mismatch (possible CSRF) — aborting")
+    _, tok = httpc.post_form(cfg.oidc_token_url, {
+        "grant_type": "authorization_code", "code": box["code"], "redirect_uri": redirect_uri,
+        "client_id": cfg.client_id, "code_verifier": verifier,
+    })
+    if tok.get("id_token") and decode_payload(tok["id_token"]).get("nonce") != nonce:
+        raise RuntimeError("id_token nonce mismatch — aborting")
+    return tok
+
+
+def refresh(cfg: Config, refresh_token: str) -> Dict:
+    """Refresh grant. Keycloak rotates the refresh token — persist the returned one."""
+    _, tok = httpc.post_form(cfg.oidc_token_url, {
+        "grant_type": "refresh_token", "refresh_token": refresh_token,
+        "client_id": cfg.client_id, "scope": OIDC_SCOPE,
+    })
+    return tok
+
+
+def revoke(cfg: Config, refresh_token: str) -> None:
+    """Best-effort refresh-token revocation at Keycloak (called on logout)."""
+    try:
+        httpc.post_form(cfg.revoke_url, {
+            "token": refresh_token, "token_type_hint": "refresh_token", "client_id": cfg.client_id,
+        })
+    except httpc.HTTPError:
+        pass

--- a/src/gasworks/store.py
+++ b/src/gasworks/store.py
@@ -1,0 +1,133 @@
+"""Credential store: ~/.config/gasworks/credentials.json (0600), atomic + cross-process locked.
+
+Holds the Keycloak refresh token, the per-org STS session + its DPoP key (PEM), and an EIA
+cache. A stolen credentials file is co-located-key vulnerable (the token scheme's acknowledged
+limit — DPoP binds the key, not the file); OS-keyring storage is a documented follow-up.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict
+
+
+def config_dir() -> Path:
+    override = os.environ.get("GASWORKS_CONFIG_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(base) / "gasworks"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return (Path(xdg) if xdg else Path.home() / ".config") / "gasworks"
+
+
+def _creds_path() -> Path:
+    return config_dir() / "credentials.json"
+
+
+def _ensure_dir() -> Path:
+    d = config_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    if os.name == "posix":
+        try:
+            os.chmod(d, 0o700)
+        except OSError:
+            pass
+    return d
+
+
+@contextmanager
+def _locked():
+    """Hold an exclusive lock around the read-modify-write of credentials.json so two
+    concurrent getToken invocations cannot lose each other's session/key."""
+    d = _ensure_dir()
+    fd = os.open(str(d / ".lock"), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        if os.name == "posix":
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            try:
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            except OSError:
+                pass  # best-effort on Windows
+        yield
+    finally:
+        if os.name == "posix":
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def load() -> Dict[str, Any]:
+    try:
+        with open(_creds_path(), "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except (json.JSONDecodeError, OSError):
+        # A corrupt/unreadable file degrades to "logged out" (re-login), never a crash.
+        return {}
+
+
+def save(data: Dict[str, Any]) -> None:
+    """Atomically write credentials.json, 0600 from creation (mkstemp is O_EXCL+0600)."""
+    d = _ensure_dir()
+    fd, tmp = tempfile.mkstemp(dir=str(d), prefix=".cred-", suffix=".tmp")
+    try:
+        if os.name == "posix":
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, str(_creds_path()))  # atomic on POSIX and Windows
+        if os.name == "nt":
+            _win_lockdown(_creds_path())
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def update():
+    """Locked read-modify-write: `with store.update() as data: data[...] = ...`."""
+    with _locked():
+        data = load()
+        yield data
+        save(data)
+
+
+def clear() -> None:
+    with _locked():
+        try:
+            os.unlink(_creds_path())
+        except FileNotFoundError:
+            pass
+
+
+def _win_lockdown(path: Path) -> None:
+    # 0600 is a no-op on Windows; best-effort restrict the file to the current user.
+    user = os.environ.get("USERNAME")
+    if not user:
+        return
+    import subprocess
+
+    try:
+        subprocess.run(
+            ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:F"],
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        pass

--- a/src/gasworks/sts.py
+++ b/src/gasworks/sts.py
@@ -1,0 +1,50 @@
+"""STS client: discovery (context), session establishment (login), and the EIA exchange (token).
+
+Each minting call carries a DPoP proof bound to the exact endpoint URL, signed by ONE key per
+session (reused across login + token so the STS's session jkt match holds). Discovery carries no
+DPoP — it mints nothing.
+"""
+
+from typing import Dict
+
+from . import httpc
+from .config import Config
+from .dpop import DPoPKey
+
+GRANT_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+def context(cfg: Config, id_token: str, provision: bool) -> Dict:
+    """GET /sts/v0/context — the caller's orgs + per-org mintable scopes (incl. manifold:pool:<name>)."""
+    url = cfg.context_url + ("?provision=true" if provision else "")
+    _, body = httpc.get(url, headers={"Authorization": f"Bearer {id_token}"})
+    return body
+
+
+def login(cfg: Config, id_token: str, org: str, dpop: DPoPKey) -> Dict:
+    """POST /sts/v0/login — establish a DPoP-bound session. Returns {session_token, expires_in, ...}."""
+    _, body = httpc.post_form(
+        cfg.login_url,
+        {"subject_token": id_token, "org": org},
+        headers={"DPoP": dpop.proof("POST", cfg.login_url)},
+    )
+    return body
+
+
+def exchange(cfg: Config, session_token: str, audience: str, scope: str, dpop: DPoPKey) -> Dict:
+    """POST /sts/v0/token — the RFC 8693 exchange. Returns {access_token: <EIA>, expires_in, scope}.
+
+    subject_token_type is intentionally OMITTED: the STS accepts only empty or the gascity session
+    URN, so the RFC-canonical access_token default would 400.
+    """
+    _, body = httpc.post_form(
+        cfg.token_url,
+        {
+            "grant_type": GRANT_TOKEN_EXCHANGE,
+            "subject_token": session_token,
+            "audience": audience,
+            "scope": scope,
+        },
+        headers={"DPoP": dpop.proof("POST", cfg.token_url)},
+    )
+    return body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+import json
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from gasworks.config import Config
+
+
+class _Stub(BaseHTTPRequestHandler):
+    """A dumb recorder: logs (path, headers, form) and responds by path. Assertions live in
+    the tests (raising in a handler thread would not surface as a clean failure)."""
+
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _record(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(n).decode() if n else ""
+        form = {k: v[0] for k, v in urllib.parse.parse_qs(raw).items()}
+        self.server.state["requests"].append(
+            {"path": self.path, "headers": dict(self.headers), "form": form}
+        )
+        return form
+
+    def do_POST(self):
+        form = self._record()
+        st = self.server.state
+        if self.path.endswith("/auth/device"):
+            self._send(200, {"device_code": "dev1", "user_code": "ABCD-EFGH",
+                             "verification_uri": "http://kc/device",
+                             "verification_uri_complete": "http://kc/device?user_code=ABCD-EFGH",
+                             "interval": 0, "expires_in": 60})
+        elif self.path.endswith("/openid-connect/token"):
+            if form.get("grant_type", "").endswith("device_code"):
+                st["device_polls"] += 1
+                if st["device_polls"] < 2:
+                    self._send(400, {"error": "authorization_pending"})
+                else:
+                    self._send(200, {"id_token": "ID.TOK.EN", "refresh_token": "RT", "access_token": "AT"})
+            else:
+                self._send(200, {"id_token": "ID2", "refresh_token": "RT2"})
+        elif self.path.endswith("/sts/v0/login"):
+            self._send(201, {"session_token": "SESS", "session_id": "ses_1",
+                             "org_id": form.get("org"), "token_type": "DPoP", "expires_in": 28800})
+        elif self.path.endswith("/sts/v0/token"):
+            self._send(200, {"access_token": "EIA.JWT", "token_type": "DPoP",
+                             "expires_in": 90, "scope": form.get("scope", "")})
+        else:
+            self._send(404, {"error": "nope"})
+
+    def do_GET(self):
+        self._record()
+        if "/sts/v0/context" in self.path:
+            self._send(200, {"user_id": "usr_1", "default_org_id": "org_a", "orgs": [
+                {"org_id": "org_a", "slug": "acme", "role": "owner", "is_default": True, "products": {
+                    "manifold": {"audience": "manifold", "scopes": ["manifold:proxy", "manifold:pool:acme"]}}}]})
+        else:
+            self._send(404, {"error": "nope"})
+
+
+@pytest.fixture
+def stub():
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Stub)
+    srv.state = {"requests": [], "device_polls": 0}
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{srv.server_address[1]}"
+    cfg = Config(sts_base=base, oidc_issuer=base + "/realms/g", client_id="gasworks-cli", loopback_port=9999)
+    try:
+        yield cfg, srv
+    finally:
+        srv.shutdown()
+
+
+def reqs(srv, suffix):
+    return [r for r in srv.state["requests"] if r["path"].endswith(suffix)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,87 @@
+import base64
+import json
+import time
+
+import pytest
+
+from gasworks import cli, store
+
+
+def _fake_jwt(claims):
+    def b(o):
+        return base64.urlsafe_b64encode(json.dumps(o).encode()).rstrip(b"=").decode()
+    return f"{b({'alg': 'none', 'typ': 'JWT'})}.{b(claims)}.sig"
+
+
+def _seed(stub_cfg, tmp_path, monkeypatch, *, creds):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("GASWORKS_STS_URL", stub_cfg.sts_base)
+    monkeypatch.setenv("GASWORKS_OIDC_ISSUER", stub_cfg.oidc_issuer)
+    monkeypatch.setenv("GASWORKS_CLIENT_ID", "gasworks-cli")
+    store.save(creds)
+
+
+def _valid_id_token():
+    return _fake_jwt({"sub": "kc-1", "email": "u@gascity.com", "exp": int(time.time()) + 3600,
+                      "aud": ["gasworks-cli"], "azp": "gasworks-cli"})
+
+
+def test_get_token_end_to_end(stub, tmp_path, monkeypatch, capsys):
+    cfg, srv = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    rc = cli.main(["getToken", "manifold"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "EIA.JWT"  # raw EIA to stdout (pipeable)
+    # discovery sent provision=true; the exchange used the discovered manifold scopes
+    tok_form = [r for r in srv.state["requests"] if r["path"].endswith("/sts/v0/token")][0]["form"]
+    assert tok_form["scope"] == "manifold:proxy manifold:pool:acme"
+    assert "subject_token_type" not in tok_form
+
+
+def test_get_token_json_envelope(stub, tmp_path, monkeypatch, capsys):
+    cfg, _ = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    cli.main(["getToken", "manifold", "--json"])
+    env = json.loads(capsys.readouterr().out.strip())
+    assert env["access_token"] == "EIA.JWT" and env["expires_in"] == 90
+
+
+def test_get_token_caches_second_call(stub, tmp_path, monkeypatch, capsys):
+    cfg, srv = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    cli.main(["getToken", "manifold"])
+    capsys.readouterr()
+    cli.main(["getToken", "manifold"])  # within 90s -> cache hit, no second mint
+    assert capsys.readouterr().out.strip() == "EIA.JWT"
+    assert len([r for r in srv.state["requests"] if r["path"].endswith("/sts/v0/token")]) == 1
+
+
+def test_get_token_unentitled_product_is_clear_error(stub, tmp_path, monkeypatch, capsys):
+    cfg, _ = stub  # the stub org_a has only manifold
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    with pytest.raises(SystemExit):
+        cli.main(["getToken", "crucible"])
+    assert "no mintable 'crucible' scope" in capsys.readouterr().err
+
+
+def test_get_token_requires_login(stub, tmp_path, monkeypatch, capsys):
+    cfg, _ = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={})  # no refresh token / id token
+    with pytest.raises(SystemExit):
+        cli.main(["getToken", "manifold"])
+    assert "not logged in" in capsys.readouterr().err
+
+
+def test_whoami(stub, tmp_path, monkeypatch, capsys):
+    cfg, _ = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    cli.main(["whoami"])
+    out = capsys.readouterr().out
+    assert "u@gascity.com" in out and "acme" in out and "manifold" in out
+
+
+def test_logout_clears(stub, tmp_path, monkeypatch, capsys):
+    cfg, _ = stub
+    _seed(cfg, tmp_path, monkeypatch, creds={"refresh_token": "RT", "id_token": _valid_id_token()})
+    cli.main(["logout"])
+    assert store.load() == {}

--- a/tests/test_dpop.py
+++ b/tests/test_dpop.py
@@ -1,0 +1,66 @@
+import json
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+from gasworks.dpop import DPoPKey
+from gasworks.jwtutil import b64url_decode
+
+
+def _parts(proof):
+    h, p, s = proof.split(".")
+    return json.loads(b64url_decode(h)), json.loads(b64url_decode(p)), b64url_decode(s)
+
+
+def test_proof_structure():
+    hdr, pl, _ = _parts(DPoPKey.generate().proof("POST", "https://works.gascity.com/sts/v0/token"))
+    assert hdr["typ"] == "dpop+jwt"
+    assert hdr["alg"] == "ES256"
+    jwk = hdr["jwk"]
+    assert jwk["kty"] == "EC" and jwk["crv"] == "P-256"
+    assert "d" not in jwk  # PUBLIC key only — never leak the private scalar
+    assert len(b64url_decode(jwk["x"])) == 32 and len(b64url_decode(jwk["y"])) == 32
+    assert pl["htm"] == "POST"
+    assert pl["htu"] == "https://works.gascity.com/sts/v0/token"
+    assert isinstance(pl["iat"], int) and pl["jti"]
+
+
+def test_signature_is_64_bytes_and_verifies_across_many_keys():
+    # golang-jwt ES256 demands exactly 64 raw bytes (r||s); a DER or variable-length sig is rejected.
+    # The 50-key sweep makes a zero-high-byte coordinate (the off-by-one bug) overwhelmingly likely.
+    htu = "https://works.gascity.com/sts/v0/login"
+    for _ in range(50):
+        h, p, s = DPoPKey.generate().proof("POST", htu).split(".")
+        sig = b64url_decode(s)
+        assert len(sig) == 64, f"sig is {len(sig)} bytes, must be exactly 64"
+        jwk = json.loads(b64url_decode(h))["jwk"]
+        x = int.from_bytes(b64url_decode(jwk["x"]), "big")
+        y = int.from_bytes(b64url_decode(jwk["y"]), "big")
+        pub = ec.EllipticCurvePublicNumbers(x, y, ec.SECP256R1()).public_key()
+        r = int.from_bytes(sig[:32], "big")
+        ss = int.from_bytes(sig[32:], "big")
+        pub.verify(encode_dss_signature(r, ss), f"{h}.{p}".encode("ascii"), ec.ECDSA(hashes.SHA256()))
+
+
+def test_fresh_jti_per_proof():
+    k = DPoPKey.generate()
+    a = _parts(k.proof("POST", "https://x/y"))[1]
+    b = _parts(k.proof("POST", "https://x/y"))[1]
+    assert a["jti"] != b["jti"]  # proofs are single-use; never cached/reused
+
+
+def test_thumbprint_stable_and_b64url_nopad():
+    k = DPoPKey.generate()
+    t = k.thumbprint()
+    assert t == k.thumbprint()
+    assert "=" not in t and "+" not in t and "/" not in t
+    assert len(b64url_decode(t)) == 32  # SHA-256
+
+
+def test_pem_roundtrip_preserves_key():
+    k = DPoPKey.generate()
+    k2 = DPoPKey.from_pem(k.to_pem())
+    # same x/y on reload -> same jwk in the proof header -> the STS's session jkt still matches
+    assert k.public_jwk() == k2.public_jwk()
+    assert k.thumbprint() == k2.thumbprint()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,0 +1,61 @@
+from gasworks import oidc, sts
+from gasworks.dpop import DPoPKey
+
+
+def _reqs(srv, suffix):
+    return [r for r in srv.state["requests"] if r["path"].endswith(suffix)]
+
+
+def test_device_login_polls_through_pending_with_pkce(stub):
+    cfg, srv = stub
+    tok = oidc.device_login(cfg, print_fn=lambda *_: None)
+    assert tok["id_token"] == "ID.TOK.EN" and tok["refresh_token"] == "RT"
+    assert srv.state["device_polls"] >= 2  # authorization_pending then success
+    dev = _reqs(srv, "/auth/device")[0]["form"]
+    assert dev["code_challenge_method"] == "S256" and dev["code_challenge"]
+    assert "openid" in dev["scope"]  # without openid Keycloak returns no id_token
+    poll = _reqs(srv, "/openid-connect/token")[-1]["form"]
+    assert poll["code_verifier"]  # PKCE verifier on the poll
+
+
+def test_login_and_exchange_omit_subject_token_type(stub):
+    cfg, srv = stub
+    dpop = DPoPKey.generate()
+    sess = sts.login(cfg, "ID.TOK.EN", "org_a", dpop)
+    assert sess["session_token"] == "SESS"
+    eia = sts.exchange(cfg, sess["session_token"], "manifold", "manifold:proxy manifold:pool:acme", dpop)
+    assert eia["access_token"] == "EIA.JWT" and eia["expires_in"] == 90
+
+    # HTTP headers are case-insensitive; urllib sends "Dpop", Go's r.Header.Get("DPoP") canonicalizes the same.
+    def has_dpop(req):
+        return any(k.lower() == "dpop" for k in req["headers"])
+
+    login_req = _reqs(srv, "/sts/v0/login")[0]
+    assert has_dpop(login_req) and login_req["form"]["subject_token"] == "ID.TOK.EN"
+    tok_req = _reqs(srv, "/sts/v0/token")[0]
+    assert has_dpop(tok_req)
+    assert tok_req["form"]["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange"
+    assert "subject_token_type" not in tok_req["form"]  # MUST be omitted (server 400s otherwise)
+    assert tok_req["form"]["subject_token"] == "SESS"  # the session token, not the id_token
+
+
+def test_context_sends_bearer_and_provision(stub):
+    cfg, srv = stub
+    ctx = sts.context(cfg, "ID.TOK.EN", provision=True)
+    assert ctx["default_org_id"] == "org_a"
+    assert ctx["orgs"][0]["products"]["manifold"]["scopes"] == ["manifold:proxy", "manifold:pool:acme"]
+    req = _reqs(srv, "provision=true")[0]
+    assert req["headers"].get("Authorization") == "Bearer ID.TOK.EN"
+
+
+def test_custom_user_agent_on_every_call(stub):
+    cfg, srv = stub
+    sts.context(cfg, "ID.TOK.EN", provision=False)
+    ua = srv.state["requests"][-1]["headers"].get("User-Agent", "")
+    assert ua.startswith("gasworks-cli/")  # never the default Python UA (Cloudflare 1010)
+
+
+def test_refresh_returns_rotated_token(stub):
+    cfg, _ = stub
+    tok = oidc.refresh(cfg, "RT")
+    assert tok["refresh_token"] == "RT2"  # rotated; the caller must persist it

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,47 @@
+import os
+import stat
+
+import gasworks.store as store
+
+
+def test_save_load_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    data = {"refresh_token": "rt", "sessions": {"org_a": {"token": "t", "dpop_pem": "..."}}}
+    store.save(data)
+    assert store.load() == data
+
+
+def test_creds_file_is_0600(tmp_path, monkeypatch):
+    if os.name != "posix":
+        return
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    store.save({"x": 1})
+    mode = stat.S_IMODE(os.stat(store._creds_path()).st_mode)
+    assert mode == 0o600, oct(mode)
+
+
+def test_update_is_read_modify_write(tmp_path, monkeypatch):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    store.save({"a": 1})
+    with store.update() as data:
+        data["b"] = 2
+    assert store.load() == {"a": 1, "b": 2}
+
+
+def test_load_missing_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "nope"))
+    assert store.load() == {}
+
+
+def test_clear_removes(tmp_path, monkeypatch):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    store.save({"x": 1})
+    store.clear()
+    assert store.load() == {}
+
+
+def test_corrupt_file_degrades_to_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("GASWORKS_CONFIG_DIR", str(tmp_path / "cfg"))
+    store.save({"x": 1})
+    store._creds_path().write_text("{not valid json", encoding="utf-8")
+    assert store.load() == {}


### PR DESCRIPTION
Lands the **Python gasworks CLI** (`src/gasworks/`) on `main`, alongside the events forwarder — it was developed on a branch divergent from main (both off `25d861e`) and never integrated, so it lived only locally.

**Additive only** — no change to the Go forwarder, `main`'s `ci.yml`/`go-ci.yml`, or the forwarder README. A separate `cli-ci.yml` runs pytest.

Commands: `login` (SSO device/browser + DPoP), `getToken <product>` (RFC 8693 → short-lived EIA, cached/auto-refreshed), `whoami`, `logout`. `pip install .` → the `gasworks` command.

Includes the OOBE polish from this effort: clearer `login --device` prompt (#43) + an actionable "no orgs" message.

**Tests:** 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gascity/codesmith/gasworks/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785346285&installation_id=141368595&pr_number=43&repository=gascity%2Fgasworks&return_to=https%3A%2F%2Fgithub.com%2Fgascity%2Fgasworks%2Fpull%2F43&signature=c9aed18cd60c5d3537a8f4f4729256d64ab20e9707cefe1c550a5e593462fce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->