### PR TITLE
feat: add stable credential-provider protocol

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,11 +21,11 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          # Pinned patch (not the floating "1.26"). The go.mod floor is `go 1.26.4` —
+          # Pinned patch (not the floating "1.26"). The go.mod floor is `go 1.26.5` —
           # REQUIRED by the github.com/gastownhall/gascity/pkg/eventexport pin (the events
-          # axis), which declares go 1.26.4. 1.26.4 is reproducible and govulncheck-clean
-          # (it also clears the stdlib CVEs that lingered at 1.24.x).
-          go-version: "1.26.4"
+          # axis), which declares go 1.26.4. 1.26.5 fixes GO-2026-5856 and the
+          # stdlib CVEs that lingered at earlier toolchain versions.
+          go-version: "1.26.5"
 
       - name: gofmt (fail on unformatted)
         run: |
@@ -57,14 +57,13 @@ jobs:
         run: go test -mod=vendor ./... -race -count=1
 
       # Vulnerability gate. Installs govulncheck pinned to a released version and fails on
-      # any reachable CVE. Proven clean against go1.26.4 (0 reachable vulns) — 1.26.4 also
-      # clears the stdlib CVEs that lingered at 1.24.x. This gate fails only on a NEW
-      # reachable CVE in the stdlib or a dependency.
+      # any reachable CVE. Proven clean against go1.26.5 (0 reachable vulns). This gate fails
+      # only on a NEW reachable CVE in the stdlib or a dependency.
       - name: govulncheck
         env:
           # govulncheck@v1.4.0's own go.mod floor is 1.25, so a default install would build
-          # it WITH 1.25 — and a 1.25-built govulncheck cannot analyze this go 1.26.4 module.
-          # GOTOOLCHAIN=local forces it to build + scan with the setup-go 1.26.4 above.
+          # it WITH 1.25 — and a 1.25-built govulncheck cannot analyze this go 1.26.5 module.
+          # GOTOOLCHAIN=local forces it to build + scan with the setup-go 1.26.5 above.
           GOTOOLCHAIN: local
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
@@ -84,7 +83,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: GoReleaser snapshot (cross-compile dry-run)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,10 +21,9 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          # Pinned patch (not the floating "1.26"). The go.mod floor is `go 1.26.5` —
-          # REQUIRED by the github.com/gastownhall/gascity/pkg/eventexport pin (the events
-          # axis), which declares go 1.26.4. 1.26.5 fixes GO-2026-5856 and the
-          # stdlib CVEs that lingered at earlier toolchain versions.
+          # Pinned patch (not the floating "1.26"). The Gas City eventexport dependency
+          # establishes a 1.26.4 baseline; this module uses 1.26.5 to fix GO-2026-5856
+          # and the stdlib CVEs that lingered at earlier toolchain versions.
           go-version: "1.26.5"
 
       - name: gofmt (fail on unformatted)
@@ -70,6 +69,18 @@ jobs:
           # No -mod flag (govulncheck doesn't accept it); with vendor/ present it scans in
           # vendor mode automatically.
           "$(go env GOPATH)/bin/govulncheck" ./...
+
+  windows-locking:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.26.5"
+
+      - name: Exercise credential-store locking on Windows
+        run: go test -mod=vendor ./internal/store ./cmd/gasworks -run '^(TestConcurrentUpdatePreservesFields|TestCredentialProvider(SerializesRefreshRotationAcrossProcesses|RecoversRefreshLockAfterProcessTermination))$' -count=1
 
   # Dry-run the release pipeline on every PR/push to PROVE the static CGO-free cross-build
   # for all targets keeps working — catches a broken .goreleaser.yaml or a non-portable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          # Pinned to 1.26.4 — REQUIRED by the go.mod floor `go 1.26.4` (set by the
+          # Pinned to 1.26.5 — REQUIRED by the go.mod floor `go 1.26.5` (set by the
           # gastownhall/gascity/pkg/eventexport pin). It builds the stdlib baked into the
-          # released binaries; 1.26.4 is govulncheck-clean (also clears the 1.24.x CVEs).
-          go-version: "1.26.4"
+          # released binaries; 1.26.5 fixes GO-2026-5856 and earlier stdlib CVEs.
+          go-version: "1.26.5"
 
       # Verify the vendored/module dependencies match their go.sum hashes before building the
       # released binaries — a tripwire against a tampered module cache or vendor tree feeding

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          # Pinned to 1.26.5 — REQUIRED by the go.mod floor `go 1.26.5` (set by the
-          # gastownhall/gascity/pkg/eventexport pin). It builds the stdlib baked into the
-          # released binaries; 1.26.5 fixes GO-2026-5856 and earlier stdlib CVEs.
+          # Pinned to the module's 1.26.5 floor. The Gas City eventexport dependency
+          # establishes a 1.26.4 baseline; 1.26.5 fixes GO-2026-5856 and earlier stdlib
+          # CVEs in the released binaries.
           go-version: "1.26.5"
 
       # Verify the vendored/module dependencies match their go.sum hashes before building the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 The `gasworks` CLI is now a single statically-linked **Go** binary. It replaces the old Python package that shipped via `pipx install git+https://github.com/gascity/gasworks`.
 
-**The commands, flags, and behavior are identical.** `login`, `getToken`, `whoami`, `logout`, and `version` work exactly as before — only the install path changes. Nothing in your scripts needs to change beyond how the binary gets onto the box.
+**The commands and flags are identical.** `login`, `getToken`, `whoami`, `logout`, and `version` keep the same invocation shape, so scripts only need to change how the binary gets onto the box. One machine-readable compatibility correction is intentional: `getToken --json` now reports the actual `Bearer` authorization scheme, truthful remaining `expires_in`, and an absolute RFC 3339 `expires_at` instead of fabricated DPoP/lifetime metadata. Consumers that asserted the old incorrect metadata must update those assertions.
 
 ## For users
 
@@ -18,7 +18,7 @@ brew install gascity/tap/gasworks
 
 `gascity/tap` is the [`gascity/homebrew-tap`](https://github.com/gascity/homebrew-tap) repo. Or download a signed binary directly from the [GitHub Releases](https://github.com/gascity/gasworks/releases).
 
-Your existing credentials carry over: the config dir is unchanged (`~/.config/gasworks`, `%APPDATA%\gasworks` on Windows, or `GASWORKS_CONFIG_DIR`), so a prior `gasworks login` session keeps working after the swap. If anything looks off, just `gasworks login` again.
+Your existing credentials carry over: the config dir is unchanged (`~/.config/gasworks`, `%APPDATA%\gasworks` on Windows, or `GASWORKS_CONFIG_DIR`), so a prior `gasworks login` session keeps working after the swap. The first mint adds a login-generation fence and discards only old cached STS sessions/EIAs; it preserves the durable refresh login. If anything looks off, just `gasworks login` again.
 
 ### Verify the signed binary
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ gasworks login --org acme      # remember a default org for getToken
 
 gasworks getToken manifold     # mint an EIA for manifold (raw token on stdout — pipeable)
 gasworks getToken crucible --org acme        # pick an org by slug or id
-gasworks getToken manifold --json            # {access_token, token_type, expires_in, scope}
+gasworks getToken manifold --json            # Bearer + truthful remaining/absolute expiry
 gasworks getToken manifold --refresh         # bypass the local EIA cache
 MANIFOLD_TOKEN=$(gasworks getToken manifold) # capture for a tool
+
+gasworks credential-provider < request.json  # versioned noninteractive JSON protocol
 
 gasworks whoami                # who you are + the orgs you can mint for
 gasworks logout                # revoke the refresh token + wipe local credentials
@@ -47,11 +49,48 @@ gasworks version               # print the build version
 |---|---|
 | `gasworks login [--device\|--browser] [--org <id\|slug>]` | SSO sign-in (browser loopback on a laptop, device-code when headless); `--org` remembers a default org. |
 | `gasworks getToken <product> [--org <id\|slug>] [--scope "<space-sep>"] [--json] [--refresh]` | Mint a short-lived EIA for a product; `--json` emits an envelope, `--refresh` bypasses the cache. |
+| `gasworks credential-provider` | Read a v1 credential request from stdin and emit one typed JSON response for automation. |
 | `gasworks whoami` | Print your subject/email and the orgs (with roles + products) you can mint for. |
 | `gasworks logout` | Revoke the refresh token at the IdP and wipe local credentials. |
 | `gasworks version` | Print the build version (`--version` also works). |
 
 You don't pass scopes or an org id by hand: `getToken` **discovers** which orgs you belong to and the exact mintable scopes per product (including the org-derived `manifold:pool:<name>` you couldn't guess). Pass `--org` only if you belong to more than one. Override the discovered scopes with `--scope "<space separated>"` only if you really need to.
+
+### Credential-provider protocol
+
+`credential-provider` is the stable, noninteractive interface for tools such as `gc`. It reads
+exactly one bounded JSON object from stdin, never starts a login flow, and writes exactly one JSON
+object to stdout. Run `gasworks login` separately to establish the durable human session.
+
+Request:
+
+```json
+{
+  "version": "gascity.dev/credential-provider/v1",
+  "audience": "manifold",
+  "required_scopes": ["manifold:proxy"],
+  "org": "",
+  "force_refresh": false,
+  "interactive": false
+}
+```
+
+Success:
+
+```json
+{
+  "version": "gascity.dev/credential-provider/v1",
+  "kind": "Credential",
+  "access_token": "<opaque>",
+  "authorization_scheme": "Bearer",
+  "expires_at": "2026-07-16T01:02:03Z",
+  "audience": "manifold",
+  "scopes": ["manifold:proxy"]
+}
+```
+
+Failures are typed JSON with `kind: "Error"` and a stable code such as
+`interaction_required`; they exit nonzero and never echo credentials or upstream response bodies.
 
 ## How it works
 

--- a/cmd/gasworks/cli_test.go
+++ b/cmd/gasworks/cli_test.go
@@ -28,6 +28,20 @@ type stubServer struct {
 	contextStatus int
 	// refreshTok is the token body returned by the Keycloak refresh grant.
 	refreshTok map[string]any
+	// refreshHandler overrides refresh-grant handling when non-nil.
+	refreshHandler func(http.ResponseWriter, *http.Request, url.Values)
+	// loginHandler overrides STS session establishment when non-nil.
+	loginHandler func(http.ResponseWriter, *http.Request, url.Values)
+	// eiaHandler overrides STS token exchange when non-nil.
+	eiaHandler func(http.ResponseWriter, *http.Request, url.Values)
+	// eiaResponse overrides the successful /sts/v0/token response when non-nil.
+	eiaResponse map[string]any
+	// productAudience overrides the context product audience when non-empty.
+	productAudience string
+	// contextErrorBody overrides a failing context response when non-nil.
+	contextErrorBody map[string]any
+	// contextResponse overrides the successful context response when non-nil.
+	contextResponse map[string]any
 }
 
 type recordedReq struct {
@@ -84,25 +98,53 @@ func newStub(t *testing.T) *stubServer {
 				"interval":                  0, "expires_in": 60,
 			})
 		case strings.HasSuffix(path, "/protocol/openid-connect/token"):
+			if form.Get("grant_type") == "refresh_token" && s.refreshHandler != nil {
+				s.refreshHandler(w, r, form)
+				return
+			}
 			// Both the refresh grant and the device-code grant land here; the CLI tests only
 			// need the token body, which is the same shape for both.
 			writeJSON(w, http.StatusOK, s.refreshTok)
 		case strings.HasSuffix(path, "/protocol/openid-connect/revoke"):
 			writeJSON(w, http.StatusOK, map[string]any{})
 		case strings.HasSuffix(path, "/sts/v0/login"):
+			if s.loginHandler != nil {
+				s.loginHandler(w, r, form)
+				return
+			}
 			writeJSON(w, http.StatusCreated, map[string]any{
 				"session_token": "SESS", "session_id": "ses_1",
 				"org_id": form.Get("org"), "token_type": "DPoP", "expires_in": 28800,
 			})
 		case strings.HasSuffix(path, "/sts/v0/token"):
-			writeJSON(w, http.StatusOK, map[string]any{
-				"access_token": "EIA.JWT", "token_type": "DPoP",
-				"expires_in": 90, "scope": form.Get("scope"),
-			})
+			if s.eiaHandler != nil {
+				s.eiaHandler(w, r, form)
+				return
+			}
+			response := s.eiaResponse
+			if response == nil {
+				response = map[string]any{
+					"access_token": "EIA.JWT", "token_type": "DPoP",
+					"expires_in": 90, "scope": form.Get("scope"),
+				}
+			}
+			writeJSON(w, http.StatusOK, response)
 		case strings.HasSuffix(path, "/sts/v0/context"):
 			if s.contextStatus != 0 {
-				writeJSON(w, s.contextStatus, map[string]any{"error": "boom"})
+				body := s.contextErrorBody
+				if body == nil {
+					body = map[string]any{"error": "boom"}
+				}
+				writeJSON(w, s.contextStatus, body)
 				return
+			}
+			if s.contextResponse != nil {
+				writeJSON(w, http.StatusOK, s.contextResponse)
+				return
+			}
+			audience := s.productAudience
+			if audience == "" {
+				audience = "manifold"
 			}
 			writeJSON(w, http.StatusOK, map[string]any{
 				"user_id": "usr_1", "default_org_id": "org_a", "orgs": []any{
@@ -110,7 +152,7 @@ func newStub(t *testing.T) *stubServer {
 						"org_id": "org_a", "slug": "acme", "role": "owner", "is_default": true,
 						"products": map[string]any{
 							"manifold": map[string]any{
-								"audience": "manifold",
+								"audience": audience,
 								"scopes":   []string{"manifold:proxy", "manifold:pool:acme"},
 							},
 						},
@@ -136,6 +178,10 @@ func seed(t *testing.T, srv *stubServer, creds map[string]any) {
 	t.Setenv("GASWORKS_OIDC_ISSUER", base+"/realms/g")
 	t.Setenv("GASWORKS_CLIENT_ID", "gasworks-cli")
 	if creds != nil {
+		if _, exists := creds["credential_generation"]; !exists &&
+			(creds["id_token"] != nil || creds["refresh_token"] != nil) {
+			creds["credential_generation"] = testCredentialGenerationA
+		}
 		writeCreds(t, creds)
 	}
 }
@@ -163,6 +209,13 @@ func capture(t *testing.T, fn func() int) (out string, errOut string, code int) 
 	defer func() { stdout, stderr = origOut, origErr }()
 	code = fn()
 	return ob.String(), eb.String(), code
+}
+
+func freezeNow(t *testing.T, instant time.Time) {
+	t.Helper()
+	originalNow := now
+	now = func() int64 { return instant.Unix() }
+	t.Cleanup(func() { now = originalNow })
 }
 
 // fakeJWT builds an unsigned JWT (alg=none) with the given claims, matching test_cli's helper.
@@ -226,6 +279,8 @@ func TestGetTokenEndToEnd(t *testing.T) {
 
 func TestGetTokenJSONEnvelope(t *testing.T) {
 	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	freezeNow(t, fixedNow)
 	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
 
 	out, errOut, code := capture(t, func() int { return run([]string{"getToken", "manifold", "--json"}) })
@@ -236,13 +291,139 @@ func TestGetTokenJSONEnvelope(t *testing.T) {
 		AccessToken string `json:"access_token"`
 		TokenType   string `json:"token_type"`
 		ExpiresIn   int    `json:"expires_in"`
+		ExpiresAt   string `json:"expires_at"`
+		Audience    string `json:"audience"`
 		Scope       string `json:"scope"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &env); err != nil {
 		t.Fatalf("not JSON: %v (out=%q)", err, out)
 	}
-	if env.AccessToken != "EIA.JWT" || env.ExpiresIn != 90 || env.TokenType != "DPoP" {
+	if env.AccessToken != "EIA.JWT" || env.ExpiresIn != 90 ||
+		env.TokenType != "Bearer" || env.Audience != "manifold" {
 		t.Fatalf("envelope = %+v", env)
+	}
+	if expiresAt, err := time.Parse(time.RFC3339, env.ExpiresAt); err != nil {
+		t.Fatalf("expires_at = %q: %v", env.ExpiresAt, err)
+	} else if !expiresAt.Equal(fixedNow.Add(90 * time.Second)) {
+		t.Fatalf("expires_at = %s, want %s", expiresAt, fixedNow.Add(90*time.Second))
+	}
+}
+
+func TestGetTokenJSONReportsCachedRemainingLifetime(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	freezeNow(t, fixedNow)
+	expiresAt := fixedNow.Add(45 * time.Second)
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "CACHED.EIA", "expires_at": expiresAt.Unix(),
+			},
+		},
+	})
+
+	out, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", "manifold:proxy", "--json"})
+	})
+	if code != 0 || errOut != "" {
+		t.Fatalf("exit=%d stderr=%q", code, errOut)
+	}
+	var envelope struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		ExpiresAt   string `json:"expires_at"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("not JSON: %v (out=%q)", err, out)
+	}
+	if envelope.AccessToken != "CACHED.EIA" || envelope.ExpiresIn != 45 ||
+		envelope.ExpiresAt != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("cached envelope = %+v", envelope)
+	}
+}
+
+func TestGetTokenDoesNotReuseCacheAfterAudienceRemap(t *testing.T) {
+	srv := newStub(t)
+	srv.productAudience = "manifold-v2"
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "OLD-AUDIENCE.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+			"org_a|manifold|manifold:proxy": map[string]any{
+				"eia": "LEGACY.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	})
+
+	out, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", "manifold:proxy", "--json"})
+	})
+	if code != 0 || errOut != "" {
+		t.Fatalf("exit=%d stderr=%q", code, errOut)
+	}
+	var envelope struct {
+		AccessToken string `json:"access_token"`
+		Audience    string `json:"audience"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("not JSON: %v (out=%q)", err, out)
+	}
+	if envelope.AccessToken != "EIA.JWT" || envelope.Audience != "manifold-v2" {
+		t.Fatalf("remapped envelope = %+v", envelope)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("audience remap made %d token requests", mints)
+	}
+}
+
+func TestGetTokenRejectsUnexpectedGrantedScopesBeforeCaching(t *testing.T) {
+	srv := newStub(t)
+	srv.eiaResponse = map[string]any{
+		"access_token": "WIDENED.EIA",
+		"expires_in":   90,
+		"scope":        "manifold:proxy manifold:admin",
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	_, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", "manifold:proxy"})
+	})
+	if code == 0 || !strings.Contains(errOut, "unexpected scopes") {
+		t.Fatalf("widened grant = exit %d stderr %q", code, errOut)
+	}
+
+	srv.eiaResponse = nil
+	response, providerErr, providerCode := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if providerCode != 0 || providerErr != "" || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("provider after rejected grant = exit %d stderr %q %+v", providerCode, providerErr, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 2 {
+		t.Fatalf("token requests = %d, want rejected legacy mint plus fresh provider mint", mints)
+	}
+}
+
+func TestGetTokenRejectsDuplicateScopes(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	_, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", "manifold:proxy manifold:proxy"})
+	})
+	if code == 0 || !strings.Contains(errOut, "duplicate") {
+		t.Fatalf("duplicate scopes = exit %d stderr %q", code, errOut)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 0 {
+		t.Fatalf("duplicate scopes made %d token requests", mints)
 	}
 }
 
@@ -263,6 +444,27 @@ func TestGetTokenCachesSecondCall(t *testing.T) {
 	// Within 90s the second call is a cache hit: exactly ONE mint total across both calls.
 	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
 		t.Fatalf("want exactly 1 EIA mint across both calls (cache hit), got %d", mints)
+	}
+}
+
+func TestGetTokenScopeOrderSharesCacheEntry(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	firstScope := "manifold:proxy manifold:pool:acme"
+	secondScope := "manifold:pool:acme manifold:proxy"
+	if _, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", firstScope})
+	}); code != 0 || errOut != "" {
+		t.Fatalf("first request = exit %d stderr %q", code, errOut)
+	}
+	if _, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", secondScope})
+	}); code != 0 || errOut != "" {
+		t.Fatalf("second request = exit %d stderr %q", code, errOut)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("scope-order requests made %d mints", mints)
 	}
 }
 
@@ -379,9 +581,57 @@ func TestLoginOrgSelection(t *testing.T) {
 	if data.RefreshToken != "RT-NEW" {
 		t.Errorf("refresh_token = %q, want the grant's RT-NEW", data.RefreshToken)
 	}
+	if !validCredentialGeneration(data.CredentialGeneration) || data.CredentialGeneration == testCredentialGenerationA {
+		t.Errorf("fresh login generation = %q, want a new valid generation", data.CredentialGeneration)
+	}
 	if len(data.Sessions) != 0 || len(data.EIACache) != 0 {
 		t.Errorf("fresh login must clear prior sessions/eia_cache: sessions=%v eia=%v",
 			data.Sessions, data.EIACache)
+	}
+}
+
+func TestLoginWithoutRefreshTokenPreservesPriorLogin(t *testing.T) {
+	srv := newStub(t)
+	srv.refreshTok = map[string]any{"id_token": validIDTokenIss(srv.srv.URL + "/realms/g")}
+	seed(t, srv, map[string]any{
+		"credential_generation": testCredentialGenerationA,
+		"id_token":              "OLD-ID",
+		"refresh_token":         "OLD-REFRESH",
+		"default_org":           "old-org",
+		"sessions":              map[string]any{"old": map[string]any{"session_token": "OLD", "dpop_pem": "OLD", "expires_at": 1}},
+		"eia_cache":             map[string]any{"old": map[string]any{"eia": "OLD", "expires_at": 1}},
+	})
+
+	_, errOut, code := capture(t, func() int { return run([]string{"login", "--device"}) })
+	if code == 0 || !strings.Contains(errOut, "refresh_token") {
+		t.Fatalf("login = exit %d stderr %q, want missing-refresh-token failure", code, errOut)
+	}
+	persisted := loadStore(t)
+	if persisted.CredentialGeneration != testCredentialGenerationA ||
+		persisted.IDToken != "OLD-ID" || persisted.RefreshToken != "OLD-REFRESH" ||
+		persisted.DefaultOrg != "old-org" || len(persisted.Sessions) != 1 || len(persisted.EIACache) != 1 {
+		t.Fatalf("failed login changed prior credentials: %+v", persisted)
+	}
+}
+
+func TestLoginWithoutOrgClearsPriorLoginDefaultOrg(t *testing.T) {
+	srv := newStub(t)
+	srv.refreshTok = map[string]any{
+		"id_token": validIDTokenIss(srv.srv.URL + "/realms/g"), "refresh_token": "RT-NEW",
+	}
+	seed(t, srv, map[string]any{
+		"credential_generation": testCredentialGenerationA,
+		"id_token":              "OLD-ID",
+		"refresh_token":         "OLD-REFRESH",
+		"default_org":           "prior-user-org",
+	})
+
+	_, errOut, code := capture(t, func() int { return run([]string{"login", "--device"}) })
+	if code != 0 {
+		t.Fatalf("login = exit %d stderr %q", code, errOut)
+	}
+	if persisted := loadStore(t); persisted.DefaultOrg != "" {
+		t.Fatalf("default_org = %q, want cleared for the new login", persisted.DefaultOrg)
 	}
 }
 

--- a/cmd/gasworks/credential_provider.go
+++ b/cmd/gasworks/credential_provider.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/gascity/gasworks/internal/config"
+)
+
+const (
+	credentialProviderProtocol = "gascity.dev/credential-provider/v1"
+	credentialRequestMaxBytes  = 64 << 10
+	credentialScopeMaxCount    = 64
+	credentialValueMaxBytes    = 512
+	credentialErrorInvalid     = "invalid_request"
+	credentialErrorInteraction = "interaction_required"
+	credentialErrorDenied      = "access_denied"
+	credentialErrorUnavailable = "temporarily_unavailable"
+)
+
+type credentialProviderRequest struct {
+	Version        string   `json:"version"`
+	Audience       string   `json:"audience"`
+	RequiredScopes []string `json:"required_scopes"`
+	Org            string   `json:"org"`
+	ForceRefresh   bool     `json:"force_refresh"`
+	Interactive    bool     `json:"interactive"`
+}
+
+type credentialProviderResponse struct {
+	Version             string   `json:"version"`
+	Kind                string   `json:"kind"`
+	AccessToken         string   `json:"access_token,omitempty"`
+	AuthorizationScheme string   `json:"authorization_scheme,omitempty"`
+	ExpiresAt           string   `json:"expires_at,omitempty"`
+	Audience            string   `json:"audience,omitempty"`
+	Scopes              []string `json:"scopes,omitempty"`
+	Code                string   `json:"code,omitempty"`
+	Message             string   `json:"message,omitempty"`
+}
+
+func cmdCredentialProvider(cfg config.Config, argv []string) int {
+	request, err := decodeCredentialProviderRequest(argv)
+	if err != nil {
+		return emitCredentialProviderError(credentialErrorInvalid)
+	}
+
+	result, err := mintEIA(
+		cfg,
+		"",
+		request.Audience,
+		request.Org,
+		strings.Join(request.RequiredScopes, " "),
+		request.ForceRefresh,
+		true,
+	)
+	if err != nil {
+		code := credentialErrorUnavailable
+		var commandErr *cmdError
+		if errors.As(err, &commandErr) && commandErr.credentialErrCode != "" {
+			code = commandErr.credentialErrCode
+		}
+		return emitCredentialProviderError(code)
+	}
+
+	response := credentialProviderResponse{
+		Version:             credentialProviderProtocol,
+		Kind:                "Credential",
+		AccessToken:         result.AccessToken,
+		AuthorizationScheme: "Bearer",
+		ExpiresAt:           time.Unix(result.ExpiresAt, 0).UTC().Format(time.RFC3339),
+		Audience:            result.Audience,
+		Scopes:              result.Scopes,
+	}
+	if err := json.NewEncoder(stdout).Encode(response); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func decodeCredentialProviderRequest(argv []string) (credentialProviderRequest, error) {
+	if len(argv) != 0 {
+		return credentialProviderRequest{}, errors.New("credential-provider accepts no arguments")
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(stdin, credentialRequestMaxBytes+1))
+	if err != nil || len(raw) > credentialRequestMaxBytes {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	if err := rejectDuplicateCredentialFields(raw); err != nil {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var request credentialProviderRequest
+	if err := decoder.Decode(&request); err != nil {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+
+	if request.Version != credentialProviderProtocol || request.Interactive {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	if !validCredentialValue(request.Audience) ||
+		(request.Org != "" && !validCredentialValue(request.Org)) {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	if len(request.RequiredScopes) == 0 || len(request.RequiredScopes) > credentialScopeMaxCount {
+		return credentialProviderRequest{}, errors.New("invalid credential request")
+	}
+	seen := make(map[string]struct{}, len(request.RequiredScopes))
+	for _, scope := range request.RequiredScopes {
+		if !validCredentialValue(scope) {
+			return credentialProviderRequest{}, errors.New("invalid credential request")
+		}
+		if _, duplicate := seen[scope]; duplicate {
+			return credentialProviderRequest{}, errors.New("invalid credential request")
+		}
+		seen[scope] = struct{}{}
+	}
+	sort.Strings(request.RequiredScopes)
+	return request, nil
+}
+
+func rejectDuplicateCredentialFields(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return errors.New("credential request must be an object")
+	}
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		field, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		name, ok := field.(string)
+		if !ok {
+			return errors.New("credential request field is not a string")
+		}
+		switch name {
+		case "version", "audience", "required_scopes", "org", "force_refresh", "interactive":
+		default:
+			return errors.New("unknown credential request field")
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return errors.New("duplicate credential request field")
+		}
+		seen[name] = struct{}{}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+	}
+	_, err = decoder.Token()
+	return err
+}
+
+func validCredentialValue(value string) bool {
+	if value == "" || len(value) > credentialValueMaxBytes {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsSpace(character) || unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func emitCredentialProviderError(code string) int {
+	message := "The credential provider could not mint a credential."
+	switch code {
+	case credentialErrorInvalid:
+		message = "The credential request is invalid."
+	case credentialErrorInteraction:
+		message = "Run `gasworks login` as the service user."
+	case credentialErrorDenied:
+		message = "The requested credential is not permitted."
+	}
+	response := credentialProviderResponse{
+		Version: credentialProviderProtocol,
+		Kind:    "Error",
+		Code:    code,
+		Message: message,
+	}
+	_ = json.NewEncoder(stdout).Encode(response)
+	return 1
+}

--- a/cmd/gasworks/credential_provider_process_test.go
+++ b/cmd/gasworks/credential_provider_process_test.go
@@ -1,0 +1,443 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gascity/gasworks/internal/config"
+)
+
+type credentialProviderProcessResult struct {
+	stdout string
+	stderr string
+	code   int
+	err    error
+}
+
+func buildGasworksCLI(t *testing.T) string {
+	t.Helper()
+	name := "gasworks-test"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), name)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "go", "build", "-mod=vendor", "-o", binary, ".")
+	if output, err := command.CombinedOutput(); err != nil {
+		if ctx.Err() != nil {
+			t.Fatalf("build gasworks CLI: %v", ctx.Err())
+		}
+		t.Fatalf("build gasworks CLI: %v\n%s", err, output)
+	}
+	return binary
+}
+
+func runCredentialProviderWaiterProcess(request, readyURL string) credentialProviderProcessResult {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestCredentialProviderWaiterHelperProcess$")
+	command.Env = append(os.Environ(),
+		"GASWORKS_TEST_WAITER_PROCESS=1",
+		"GASWORKS_TEST_WAITER_REQUEST="+request,
+		"GASWORKS_TEST_WAITER_READY_URL="+readyURL,
+	)
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	command.Stdout = &stdoutBuffer
+	command.Stderr = &stderrBuffer
+	err := command.Run()
+	if ctx.Err() != nil {
+		return credentialProviderProcessResult{stdout: stdoutBuffer.String(), stderr: stderrBuffer.String(), code: -1, err: ctx.Err()}
+	}
+	exitCode := 0
+	if err != nil {
+		var exitError *exec.ExitError
+		if !errors.As(err, &exitError) {
+			return credentialProviderProcessResult{stdout: stdoutBuffer.String(), stderr: stderrBuffer.String(), code: -1, err: err}
+		}
+		exitCode = exitError.ExitCode()
+	}
+	return credentialProviderProcessResult{
+		stdout: stdoutBuffer.String(), stderr: stderrBuffer.String(), code: exitCode,
+	}
+}
+
+func credentialProviderWaiterBarrier(t *testing.T) (string, <-chan struct{}, <-chan struct{}, func()) {
+	t.Helper()
+	ready := make(chan struct{})
+	armed := make(chan struct{})
+	release := make(chan struct{})
+	var readyOnce, armedOnce, releaseOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/armed" {
+			armedOnce.Do(func() { close(armed) })
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		readyOnce.Do(func() { close(ready) })
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	releaseWaiter := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(func() {
+		releaseWaiter()
+		server.Close()
+	})
+	return server.URL, ready, armed, releaseWaiter
+}
+
+func TestCredentialProviderWaiterHelperProcess(t *testing.T) {
+	if os.Getenv("GASWORKS_TEST_WAITER_PROCESS") != "1" {
+		return
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	_, err := ensureIDTokenBeforeRefreshTransaction(config.FromEnv(), func() {
+		response, requestErr := client.Get(os.Getenv("GASWORKS_TEST_WAITER_READY_URL"))
+		if requestErr != nil {
+			os.Exit(90)
+		}
+		_ = response.Body.Close()
+		response, requestErr = client.Get(os.Getenv("GASWORKS_TEST_WAITER_READY_URL") + "/armed")
+		if requestErr != nil {
+			os.Exit(92)
+		}
+		_ = response.Body.Close()
+	})
+	if err != nil {
+		os.Exit(91)
+	}
+	stdin = strings.NewReader(os.Getenv("GASWORKS_TEST_WAITER_REQUEST"))
+	os.Exit(run([]string{"credential-provider"}))
+}
+
+func runGasworksCLIProcess(binary, request string) (string, string, int, error) {
+	return runGasworksCLIProcessStarted(binary, request, nil)
+}
+
+func runGasworksCLIProcessStarted(binary, request string, started chan<- struct{}) (string, string, int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binary, "credential-provider")
+	command.Stdin = strings.NewReader(request)
+	command.Env = os.Environ()
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	command.Stdout = &stdoutBuffer
+	command.Stderr = &stderrBuffer
+	if err := command.Start(); err != nil {
+		return stdoutBuffer.String(), stderrBuffer.String(), -1, err
+	}
+	if started != nil {
+		close(started)
+	}
+	err := command.Wait()
+	if ctx.Err() != nil {
+		return stdoutBuffer.String(), stderrBuffer.String(), -1, ctx.Err()
+	}
+	exitCode := 0
+	if err != nil {
+		var exitError *exec.ExitError
+		if !errors.As(err, &exitError) {
+			return stdoutBuffer.String(), stderrBuffer.String(), -1, err
+		}
+		exitCode = exitError.ExitCode()
+	}
+	return stdoutBuffer.String(), stderrBuffer.String(), exitCode, nil
+}
+
+func decodeProcessResponse(t *testing.T, output string) credentialProviderTestResponse {
+	t.Helper()
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.DisallowUnknownFields()
+	var response credentialProviderTestResponse
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatalf("decode process response: %v (output=%q)", err, output)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		t.Fatalf("process emitted more than one JSON object: %v (output=%q)", err, output)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &fields); err != nil {
+		t.Fatalf("decode process response fields: %v (output=%q)", err, output)
+	}
+	var expected []string
+	switch response.Kind {
+	case "Credential":
+		expected = []string{"version", "kind", "access_token", "authorization_scheme", "expires_at", "audience", "scopes"}
+	case "Error":
+		expected = []string{"version", "kind", "code", "message"}
+	default:
+		t.Fatalf("process response has invalid kind %q", response.Kind)
+	}
+	if len(fields) != len(expected) {
+		t.Fatalf("process response fields = %v, want exactly %v", fieldNames(fields), expected)
+	}
+	for _, field := range expected {
+		if _, ok := fields[field]; !ok {
+			t.Fatalf("process response fields = %v, missing %q", fieldNames(fields), field)
+		}
+	}
+	return response
+}
+
+func fieldNames(fields map[string]json.RawMessage) []string {
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestCredentialProviderRealProcessProtocol(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+	binary := buildGasworksCLI(t)
+	validRequest := `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`
+
+	stdoutText, stderrText, code, err := runGasworksCLIProcess(binary, validRequest)
+	if err != nil {
+		t.Fatalf("run success process: %v", err)
+	}
+	response := decodeProcessResponse(t, stdoutText)
+	if code != 0 || stderrText != "" || response.Kind != "Credential" || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("success process = exit %d stderr %q response %+v", code, stderrText, response)
+	}
+
+	requestSecret := "REQUEST-SECRET-SENTINEL"
+	invalidRequest := `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"token":"` + requestSecret + `"}`
+	stdoutText, stderrText, code, err = runGasworksCLIProcess(binary, invalidRequest)
+	if err != nil {
+		t.Fatalf("run invalid process: %v", err)
+	}
+	response = decodeProcessResponse(t, stdoutText)
+	if code == 0 || stderrText != "" || response.Kind != "Error" || response.Code != "invalid_request" {
+		t.Fatalf("invalid process = exit %d stderr %q response %+v", code, stderrText, response)
+	}
+	if strings.Contains(stdoutText+stderrText, requestSecret) {
+		t.Fatalf("invalid process leaked request secret: stdout=%q stderr=%q", stdoutText, stderrText)
+	}
+
+	upstreamSecret := "UPSTREAM-SECRET-SENTINEL"
+	srv.contextStatus = http.StatusInternalServerError
+	srv.contextErrorBody = map[string]any{"error": "temporarily_unavailable", "error_description": upstreamSecret}
+	stdoutText, stderrText, code, err = runGasworksCLIProcess(binary, validRequest)
+	if err != nil {
+		t.Fatalf("run upstream-failure process: %v", err)
+	}
+	response = decodeProcessResponse(t, stdoutText)
+	if code == 0 || stderrText != "" || response.Kind != "Error" || response.Code != "temporarily_unavailable" {
+		t.Fatalf("upstream process = exit %d stderr %q response %+v", code, stderrText, response)
+	}
+	if strings.Contains(stdoutText+stderrText, upstreamSecret) {
+		t.Fatalf("process leaked upstream secret: stdout=%q stderr=%q", stdoutText, stderrText)
+	}
+}
+
+func TestCredentialProviderSerializesRefreshRotationAcrossProcesses(t *testing.T) {
+	srv := newStub(t)
+	var refreshes atomic.Int32
+	firstRefreshStarted := make(chan struct{})
+	secondRefreshStarted := make(chan struct{})
+	releaseFirstRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirstRefresh) }) }
+	defer release()
+	srv.refreshHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+		attempt := refreshes.Add(1)
+		if attempt == 2 {
+			close(secondRefreshStarted)
+		}
+		if form.Get("refresh_token") != "RT-OLD" || attempt != 1 {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_grant"})
+			return
+		}
+		close(firstRefreshStarted)
+		<-releaseFirstRefresh
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id_token": validIDToken(), "refresh_token": "RT-NEW",
+		})
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT-OLD", "id_token": expiredIDToken()})
+	binary := buildGasworksCLI(t)
+	request := `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`
+
+	results := make(chan credentialProviderProcessResult, 2)
+	var wait sync.WaitGroup
+	wait.Add(1)
+	go func() {
+		defer wait.Done()
+		stdoutText, stderrText, code, err := runGasworksCLIProcess(binary, request)
+		results <- credentialProviderProcessResult{stdout: stdoutText, stderr: stderrText, code: code, err: err}
+	}()
+	select {
+	case <-firstRefreshStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first process did not enter refresh transaction")
+	}
+
+	readyURL, waiterReady, waiterArmed, releaseWaiter := credentialProviderWaiterBarrier(t)
+	wait.Add(1)
+	go func() {
+		defer wait.Done()
+		results <- runCredentialProviderWaiterProcess(request, readyURL)
+	}()
+	select {
+	case <-waiterReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second process did not reach the pre-lock refresh barrier")
+	}
+	releaseWaiter()
+	select {
+	case <-waiterArmed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second process did not arm immediately before lock acquisition")
+	}
+	select {
+	case <-secondRefreshStarted:
+		t.Fatal("second process entered refresh while the first transaction held the store lock")
+	case <-time.After(time.Second):
+	}
+	release()
+	wait.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("run concurrent process: %v", result.err)
+		}
+		response := decodeProcessResponse(t, result.stdout)
+		expiresAt, expiryErr := time.Parse(time.RFC3339, response.ExpiresAt)
+		if result.code != 0 || result.stderr != "" || response.Kind != "Credential" ||
+			response.AccessToken != "EIA.JWT" || response.AuthorizationScheme != "Bearer" ||
+			response.Audience != "manifold" || !slices.Equal(response.Scopes, []string{"manifold:proxy"}) ||
+			expiryErr != nil || !expiresAt.After(time.Now()) {
+			t.Fatalf("concurrent process = exit %d stderr %q response %+v", result.code, result.stderr, response)
+		}
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refresh transactions = %d, want 1", got)
+	}
+	credentials := loadStore(t)
+	if credentials.RefreshToken != "RT-NEW" || tokenExp(credentials.IDToken)-time.Now().Unix() <= idTokenSkewSecs {
+		t.Fatalf("persisted refresh state = refresh_token %q id_token_exp %d", credentials.RefreshToken, tokenExp(credentials.IDToken))
+	}
+}
+
+func TestCredentialProviderRecoversRefreshLockAfterProcessTermination(t *testing.T) {
+	srv := newStub(t)
+	var refreshes atomic.Int32
+	firstRefreshStarted := make(chan struct{})
+	firstRefreshCanceled := make(chan struct{})
+	secondRefreshStarted := make(chan struct{})
+	srv.refreshHandler = func(w http.ResponseWriter, request *http.Request, form url.Values) {
+		attempt := refreshes.Add(1)
+		if form.Get("refresh_token") != "RT-OLD" {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_grant"})
+			return
+		}
+		if attempt == 1 {
+			close(firstRefreshStarted)
+			<-request.Context().Done()
+			close(firstRefreshCanceled)
+			return
+		}
+		close(secondRefreshStarted)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id_token": validIDToken(), "refresh_token": "RT-NEW",
+		})
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT-OLD", "id_token": expiredIDToken()})
+	binary := buildGasworksCLI(t)
+	request := `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	holder := exec.CommandContext(ctx, binary, "credential-provider")
+	holder.Stdin = strings.NewReader(request)
+	holder.Env = os.Environ()
+	var holderStdout, holderStderr bytes.Buffer
+	holder.Stdout = &holderStdout
+	holder.Stderr = &holderStderr
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	defer func() {
+		if holder.ProcessState == nil {
+			_ = holder.Process.Kill()
+			_ = holder.Wait()
+		}
+	}()
+	select {
+	case <-firstRefreshStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("lock holder did not enter refresh transaction")
+	}
+	readyURL, waiterReady, waiterArmed, releaseWaiter := credentialProviderWaiterBarrier(t)
+	waiterResult := make(chan credentialProviderProcessResult, 1)
+	go func() { waiterResult <- runCredentialProviderWaiterProcess(request, readyURL) }()
+	select {
+	case <-waiterReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery process did not reach the pre-lock refresh barrier")
+	}
+	releaseWaiter()
+	select {
+	case <-waiterArmed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery process did not arm immediately before lock acquisition")
+	}
+	select {
+	case <-secondRefreshStarted:
+		t.Fatal("recovery process entered refresh before the lock holder terminated")
+	case <-time.After(time.Second):
+	}
+	if err := holder.Process.Kill(); err != nil {
+		t.Fatalf("terminate lock holder: %v", err)
+	}
+	if err := holder.Wait(); err == nil {
+		t.Fatal("terminated lock holder exited successfully")
+	}
+	select {
+	case <-firstRefreshCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminated process did not cancel its in-flight refresh")
+	}
+
+	var result credentialProviderProcessResult
+	select {
+	case result = <-waiterResult:
+	case <-time.After(10 * time.Second):
+		t.Fatal("recovery process did not finish after lock-holder termination")
+	}
+	if result.err != nil {
+		t.Fatalf("run recovery process: %v", result.err)
+	}
+	response := decodeProcessResponse(t, result.stdout)
+	if result.code != 0 || result.stderr != "" || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("recovery process = exit %d stderr %q response %+v", result.code, result.stderr, response)
+	}
+	if got := refreshes.Load(); got != 2 {
+		t.Fatalf("refresh attempts = %d, want canceled holder plus successful recovery", got)
+	}
+	credentials := loadStore(t)
+	if credentials.RefreshToken != "RT-NEW" || tokenExp(credentials.IDToken)-time.Now().Unix() <= idTokenSkewSecs {
+		t.Fatalf("recovered refresh state = refresh_token %q id_token_exp %d", credentials.RefreshToken, tokenExp(credentials.IDToken))
+	}
+}

--- a/cmd/gasworks/credential_provider_test.go
+++ b/cmd/gasworks/credential_provider_test.go
@@ -1,0 +1,1260 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gascity/gasworks/internal/store"
+)
+
+const credentialProviderVersion = "gascity.dev/credential-provider/v1"
+
+const (
+	testCredentialGenerationA = "g1:00000000000000000000000000000001"
+	testCredentialGenerationB = "g1:00000000000000000000000000000002"
+)
+
+type credentialProviderTestResponse struct {
+	Version             string   `json:"version"`
+	Kind                string   `json:"kind"`
+	AccessToken         string   `json:"access_token"`
+	AuthorizationScheme string   `json:"authorization_scheme"`
+	ExpiresAt           string   `json:"expires_at"`
+	Audience            string   `json:"audience"`
+	Scopes              []string `json:"scopes"`
+	Code                string   `json:"code"`
+	Message             string   `json:"message"`
+}
+
+func runCredentialProvider(t *testing.T, request string) (credentialProviderTestResponse, string, int) {
+	return runCredentialProviderCommand(t, []string{"credential-provider"}, request)
+}
+
+func runCredentialProviderCommand(t *testing.T, argv []string, request string) (credentialProviderTestResponse, string, int) {
+	t.Helper()
+	out, errOut, code := runCredentialProviderCommandRaw(t, argv, request)
+	response := decodeProcessResponse(t, out)
+	return response, errOut, code
+}
+
+func runCredentialProviderCommandRaw(t *testing.T, argv []string, request string) (string, string, int) {
+	t.Helper()
+
+	originalStdin := stdin
+	stdin = strings.NewReader(request)
+	defer func() { stdin = originalStdin }()
+
+	out, errOut, code := capture(t, func() int { return run(argv) })
+	return out, errOut, code
+}
+
+func TestCredentialProviderRejectsCommandArguments(t *testing.T) {
+	response, errOut, code := runCredentialProviderCommand(
+		t,
+		[]string{"credential-provider", "--org", "acme"},
+		`{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"]}`,
+	)
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != "invalid_request" {
+		t.Fatalf("argument response = exit %d stderr %q %+v", code, errOut, response)
+	}
+}
+
+func TestCredentialProviderMintsRequestedScopes(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	freezeNow(t, fixedNow)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	request := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"org":"",
+		"force_refresh":false,
+		"interactive":false
+	}`
+	response, errOut, code := runCredentialProvider(t, request)
+
+	if code != 0 || errOut != "" {
+		t.Fatalf("exit=%d stderr=%q, want clean success", code, errOut)
+	}
+	if response.Version != credentialProviderVersion || response.Kind != "Credential" {
+		t.Fatalf("response identity = version %q kind %q", response.Version, response.Kind)
+	}
+	if response.AccessToken != "EIA.JWT" || response.AuthorizationScheme != "Bearer" {
+		t.Fatalf("credential = token %q scheme %q", response.AccessToken, response.AuthorizationScheme)
+	}
+	if response.Audience != "manifold" || !slices.Equal(response.Scopes, []string{"manifold:proxy"}) {
+		t.Fatalf("authority = audience %q scopes %v", response.Audience, response.Scopes)
+	}
+	expiresAt, err := time.Parse(time.RFC3339, response.ExpiresAt)
+	if err != nil {
+		t.Fatalf("expires_at = %q: %v", response.ExpiresAt, err)
+	}
+	if !expiresAt.Equal(fixedNow.Add(90 * time.Second)) {
+		t.Fatalf("expires_at = %s, want %s", expiresAt, fixedNow.Add(90*time.Second))
+	}
+
+	mints := srv.reqs("/sts/v0/token")
+	if len(mints) != 1 || mints[0].form.Get("scope") != "manifold:proxy" {
+		t.Fatalf("mint requests = %+v, want only required scope", mints)
+	}
+}
+
+func TestCredentialProviderForceRefreshBypassesCache(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "CACHED.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	})
+
+	response, _, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"force_refresh":true,
+		"interactive":false
+	}`)
+
+	if code != 0 || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("force-refresh response = code %d %+v", code, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("force refresh made %d token requests", mints)
+	}
+}
+
+func TestCredentialProviderFailedForceRefreshInvalidatesRejectedCache(t *testing.T) {
+	srv := newStub(t)
+	srv.eiaResponse = map[string]any{
+		"access_token": "INVALID.EIA",
+		"scope":        "manifold:proxy",
+	}
+	cacheKey := eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"})
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			cacheKey: map[string]any{
+				"eia": "REJECTED.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	})
+	request := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"force_refresh":true,
+		"interactive":false
+	}`
+
+	if response, _, code := runCredentialProvider(t, request); code == 0 || response.Kind != "Error" {
+		t.Fatalf("failed forced refresh = exit %d %+v", code, response)
+	}
+	srv.eiaResponse = nil
+	out, errOut, code := capture(t, func() int {
+		return run([]string{"getToken", "manifold", "--scope", "manifold:proxy"})
+	})
+	if code != 0 || errOut != "" || strings.TrimSpace(out) != "EIA.JWT" {
+		t.Fatalf("ordinary retry = exit %d stdout %q stderr %q", code, out, errOut)
+	}
+	if strings.Contains(out, "REJECTED.EIA") {
+		t.Fatal("rejected cached credential was reused")
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 2 {
+		t.Fatalf("mint requests = %d, want failed force plus ordinary retry", mints)
+	}
+}
+
+func TestCredentialProviderRejectsMissingExpiry(t *testing.T) {
+	srv := newStub(t)
+	srv.eiaResponse = map[string]any{
+		"access_token": "EIA.JWT",
+		"scope":        "manifold:proxy",
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != "temporarily_unavailable" {
+		t.Fatalf("missing-expiry response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if strings.Contains(response.Message, "EIA.JWT") {
+		t.Fatalf("error leaked token: %+v", response)
+	}
+}
+
+func TestCredentialProviderRejectsMixedAllowedAndForbiddenScopes(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy","manifold:admin"],
+		"interactive":false
+	}`)
+
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != "access_denied" {
+		t.Fatalf("mixed-scope response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 0 {
+		t.Fatalf("denied mixed scopes made %d token requests", mints)
+	}
+}
+
+func TestCredentialProviderRejectsUnexpectedGrantedScope(t *testing.T) {
+	srv := newStub(t)
+	srv.eiaResponse = map[string]any{
+		"access_token": "EIA.JWT",
+		"expires_in":   90,
+		"scope":        "manifold:proxy manifold:admin",
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	request := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`
+	response, errOut, code := runCredentialProvider(t, request)
+
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != "access_denied" {
+		t.Fatalf("widened-grant response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if response.AccessToken != "" || strings.Contains(response.Message, "EIA.JWT") {
+		t.Fatalf("widened grant leaked a credential: %+v", response)
+	}
+
+	srv.eiaResponse = nil
+	response, errOut, code = runCredentialProvider(t, request)
+	if code != 0 || errOut != "" || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("retry after widened grant = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 2 {
+		t.Fatalf("widened grant was cached: token requests = %d, want 2", mints)
+	}
+}
+
+func TestCredentialProviderIgnoresMalformedCachedCredential(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "  ", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	})
+
+	response, _, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+
+	if code != 0 || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("malformed-cache response = exit %d %+v", code, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("malformed cache made %d token requests", mints)
+	}
+}
+
+func TestCredentialProviderDoesNotReuseLegacyCacheAfterAudienceRemap(t *testing.T) {
+	srv := newStub(t)
+	srv.productAudience = "manifold-v2"
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "OLD-AUDIENCE.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+			"org_a|manifold|manifold:proxy": map[string]any{
+				"eia": "LEGACY.EIA", "expires_at": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	})
+
+	response, _, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold-v2",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+
+	if code != 0 || response.AccessToken != "EIA.JWT" || response.Audience != "manifold-v2" {
+		t.Fatalf("remapped response = exit %d %+v", code, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("audience remap made %d token requests", mints)
+	}
+	if audience := srv.reqs("/sts/v0/token")[0].form.Get("audience"); audience != "manifold-v2" {
+		t.Fatalf("audience remap minted for %q, want manifold-v2", audience)
+	}
+}
+
+func TestCredentialProviderClassifiesRefreshFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		oauthError string
+		wantCode   string
+	}{
+		{name: "terminal rejection", status: 400, oauthError: "invalid_grant", wantCode: "interaction_required"},
+		{name: "transient service failure", status: 503, oauthError: "temporarily_unavailable", wantCode: "temporarily_unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStub(t)
+			srv.refreshHandler = func(w http.ResponseWriter, _ *http.Request, _ url.Values) {
+				writeJSON(w, tt.status, map[string]any{"error": tt.oauthError, "error_description": "UPSTREAM-SECRET"})
+			}
+			seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": expiredIDToken()})
+
+			response, errOut, code := runCredentialProvider(t, `{
+				"version":"gascity.dev/credential-provider/v1",
+				"audience":"manifold",
+				"required_scopes":["manifold:proxy"],
+				"interactive":false
+			}`)
+
+			if code == 0 || errOut != "" || response.Code != tt.wantCode {
+				t.Fatalf("refresh failure = exit %d stderr %q %+v", code, errOut, response)
+			}
+			encoded, _ := json.Marshal(response)
+			if strings.Contains(string(encoded), "UPSTREAM-SECRET") {
+				t.Fatalf("refresh failure leaked upstream body: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestCredentialProviderClassifiesSessionAndExchangeFailures(t *testing.T) {
+	const request = `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`
+	assertError := func(t *testing.T, srv *stubServer, wantCode, secret string, wantLogins, wantExchanges int) {
+		t.Helper()
+		out, errOut, code := runCredentialProviderCommandRaw(t, []string{"credential-provider"}, request)
+		response := decodeProcessResponse(t, out)
+		if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != wantCode {
+			t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+		}
+		if strings.Contains(out+errOut, secret) || response.AccessToken != "" {
+			t.Fatalf("response leaked secret or credential: stdout=%q stderr=%q", out, errOut)
+		}
+		if logins := len(srv.reqs("/sts/v0/login")); logins != wantLogins {
+			t.Fatalf("login requests = %d, want %d", logins, wantLogins)
+		}
+		if exchanges := len(srv.reqs("/sts/v0/token")); exchanges != wantExchanges {
+			t.Fatalf("exchange requests = %d, want %d", exchanges, wantExchanges)
+		}
+		if entries := len(loadStore(t).EIACache); entries != 0 {
+			t.Fatalf("failed request cached %d credentials", entries)
+		}
+	}
+
+	for _, test := range []struct {
+		name     string
+		status   int
+		wantCode string
+	}{
+		{name: "login forbidden", status: http.StatusForbidden, wantCode: credentialErrorDenied},
+		{name: "login unavailable", status: http.StatusInternalServerError, wantCode: credentialErrorUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const secret = "LOGIN-UPSTREAM-SECRET"
+			srv := newStub(t)
+			srv.loginHandler = func(w http.ResponseWriter, _ *http.Request, _ url.Values) {
+				writeJSON(w, test.status, map[string]any{"error": "rejected", "error_description": secret})
+			}
+			seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+			assertError(t, srv, test.wantCode, secret, 1, 0)
+		})
+	}
+
+	for _, test := range []struct {
+		name          string
+		status        int
+		wantCode      string
+		wantExchanges int
+	}{
+		{name: "exchange forbidden", status: http.StatusForbidden, wantCode: credentialErrorDenied, wantExchanges: 1},
+		{name: "exchange unavailable", status: http.StatusInternalServerError, wantCode: credentialErrorUnavailable, wantExchanges: 1},
+		{name: "exchange retry rejected", status: http.StatusUnauthorized, wantCode: credentialErrorUnavailable, wantExchanges: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const secret = "EXCHANGE-UPSTREAM-SECRET"
+			srv := newStub(t)
+			srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, _ url.Values) {
+				writeJSON(w, test.status, map[string]any{"error": "rejected", "error_description": secret})
+			}
+			seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+			wantLogins := 1
+			if test.status == http.StatusUnauthorized {
+				wantLogins = 2
+			}
+			assertError(t, srv, test.wantCode, secret, wantLogins, test.wantExchanges)
+		})
+	}
+
+	t.Run("401 retry succeeds", func(t *testing.T) {
+		srv := newStub(t)
+		var exchanges atomic.Int32
+		srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+			if exchanges.Add(1) == 1 {
+				writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "expired", "error_description": "FIRST-SECRET"})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"access_token": "RETRIED.EIA", "expires_in": 90, "scope": form.Get("scope"),
+			})
+		}
+		seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+		out, errOut, code := runCredentialProviderCommandRaw(t, []string{"credential-provider"}, request)
+		response := decodeProcessResponse(t, out)
+		if code != 0 || errOut != "" || response.Kind != "Credential" || response.AccessToken != "RETRIED.EIA" || strings.Contains(out, "FIRST-SECRET") {
+			t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+		}
+		if logins := len(srv.reqs("/sts/v0/login")); logins != 2 {
+			t.Fatalf("login requests = %d, want 2", logins)
+		}
+		if got := exchanges.Load(); got != 2 {
+			t.Fatalf("exchange requests = %d, want 2", got)
+		}
+		if entries := len(loadStore(t).EIACache); entries != 1 {
+			t.Fatalf("successful retry cached %d credentials, want 1", entries)
+		}
+	})
+
+	t.Run("401 retry forbidden", func(t *testing.T) {
+		const secret = "RETRY-FORBIDDEN-SECRET"
+		srv := newStub(t)
+		var exchanges atomic.Int32
+		srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, _ url.Values) {
+			status := http.StatusUnauthorized
+			if exchanges.Add(1) == 2 {
+				status = http.StatusForbidden
+			}
+			writeJSON(w, status, map[string]any{"error": "rejected", "error_description": secret})
+		}
+		seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+		assertError(t, srv, credentialErrorDenied, secret, 2, 2)
+	})
+}
+
+func TestCredentialProviderRejectsRefreshWithoutIDToken(t *testing.T) {
+	srv := newStub(t)
+	srv.refreshTok = map[string]any{"refresh_token": "RT-ROTATED"}
+	seed(t, srv, map[string]any{"refresh_token": "RT-OLD", "id_token": expiredIDToken()})
+
+	out, errOut, code := runCredentialProviderCommandRaw(t, []string{"credential-provider"}, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	response := decodeProcessResponse(t, out)
+	if code == 0 || errOut != "" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if refreshes := len(srv.reqs("/protocol/openid-connect/token")); refreshes != 1 {
+		t.Fatalf("refresh requests = %d, want 1", refreshes)
+	}
+	credentials := loadStore(t)
+	if credentials.RefreshToken != "RT-OLD" || len(credentials.EIACache) != 0 {
+		t.Fatalf("failed refresh changed durable credentials: %+v", credentials)
+	}
+}
+
+func TestCredentialProviderRequiresOrgForAmbiguousAccount(t *testing.T) {
+	srv := newStub(t)
+	srv.contextResponse = map[string]any{
+		"user_id": "usr_1",
+		"orgs": []any{
+			map[string]any{"org_id": "org_a", "slug": "a", "products": map[string]any{"manifold": map[string]any{"audience": "manifold", "scopes": []string{"manifold:proxy"}}}},
+			map[string]any{"org_id": "org_b", "slug": "b", "products": map[string]any{"manifold": map[string]any{"audience": "manifold", "scopes": []string{"manifold:proxy"}}}},
+		},
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if code == 0 || errOut != "" || response.Code != credentialErrorInvalid {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if logins := len(srv.reqs("/sts/v0/login")); logins != 0 {
+		t.Fatalf("ambiguous account made %d login requests", logins)
+	}
+	if exchanges := len(srv.reqs("/sts/v0/token")); exchanges != 0 {
+		t.Fatalf("ambiguous account made %d exchange requests", exchanges)
+	}
+	if entries := len(loadStore(t).EIACache); entries != 0 {
+		t.Fatalf("ambiguous account cached %d credentials", entries)
+	}
+}
+
+func TestCredentialProviderExpiryUsesExchangeStartTime(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	var clock atomic.Int64
+	clock.Store(fixedNow.Unix())
+	originalNow := now
+	now = clock.Load
+	t.Cleanup(func() { now = originalNow })
+	srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+		clock.Add(30)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"access_token": "EIA.JWT", "expires_in": 90, "scope": form.Get("scope"),
+		})
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if code != 0 || errOut != "" || response.ExpiresAt != fixedNow.Add(90*time.Second).Format(time.RFC3339) {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+}
+
+func TestCredentialProviderRejectsCredentialExpiredInTransit(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	var clock atomic.Int64
+	clock.Store(fixedNow.Unix())
+	originalNow := now
+	now = clock.Load
+	t.Cleanup(func() { now = originalNow })
+	srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+		clock.Add(90)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"access_token": "EXPIRED.EIA", "expires_in": 60, "scope": form.Get("scope"),
+		})
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if code == 0 || errOut != "" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if entries := len(loadStore(t).EIACache); entries != 0 {
+		t.Fatalf("expired response cached %d credentials", entries)
+	}
+}
+
+func TestCredentialProviderRejectsOverflowingExpiry(t *testing.T) {
+	srv := newStub(t)
+	srv.eiaResponse = map[string]any{
+		"access_token": "EIA.JWT",
+		"expires_in":   int64(math.MaxInt64 - (1 << 20)),
+		"scope":        "manifold:proxy",
+	}
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if code == 0 || errOut != "" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if entries := len(loadStore(t).EIACache); entries != 0 {
+		t.Fatalf("overflowing response cached %d credentials", entries)
+	}
+}
+
+func TestCredentialProviderReportsCachedAbsoluteExpiry(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	freezeNow(t, fixedNow)
+	expiresAt := fixedNow.Add(45 * time.Second)
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+				"eia": "CACHED.EIA", "expires_at": expiresAt.Unix(),
+			},
+		},
+	})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+
+	if code != 0 || errOut != "" {
+		t.Fatalf("exit=%d stderr=%q, want clean cache hit", code, errOut)
+	}
+	if response.AccessToken != "CACHED.EIA" || response.ExpiresAt != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("cached response = token %q expires_at %q", response.AccessToken, response.ExpiresAt)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 0 {
+		t.Fatalf("cache hit made %d token requests", mints)
+	}
+}
+
+func TestCredentialProviderCacheFreshnessBoundary(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	for _, test := range []struct {
+		name          string
+		remaining     time.Duration
+		wantToken     string
+		wantExpiresAt time.Time
+		wantMints     int
+	}{
+		{
+			name:          "at skew remints",
+			remaining:     time.Duration(eiaSkewSecs) * time.Second,
+			wantToken:     "EIA.JWT",
+			wantExpiresAt: fixedNow.Add(90 * time.Second),
+			wantMints:     1,
+		},
+		{
+			name:          "one second above skew hits",
+			remaining:     time.Duration(eiaSkewSecs+1) * time.Second,
+			wantToken:     "CACHED.EIA",
+			wantExpiresAt: fixedNow.Add(time.Duration(eiaSkewSecs+1) * time.Second),
+			wantMints:     0,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newStub(t)
+			freezeNow(t, fixedNow)
+			seed(t, srv, map[string]any{
+				"refresh_token": "RT",
+				"id_token":      validIDToken(),
+				"eia_cache": map[string]any{
+					eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"}): map[string]any{
+						"eia": "CACHED.EIA", "expires_at": fixedNow.Add(test.remaining).Unix(),
+					},
+				},
+			})
+
+			response, errOut, code := runCredentialProvider(t, `{
+				"version":"gascity.dev/credential-provider/v1",
+				"audience":"manifold",
+				"required_scopes":["manifold:proxy"],
+				"interactive":false
+			}`)
+			if code != 0 || errOut != "" || response.AccessToken != test.wantToken ||
+				response.ExpiresAt != test.wantExpiresAt.Format(time.RFC3339) {
+				t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+			}
+			if mints := len(srv.reqs("/sts/v0/token")); mints != test.wantMints {
+				t.Fatalf("mint requests = %d, want %d", mints, test.wantMints)
+			}
+		})
+	}
+}
+
+func TestCredentialProviderDoesNotReuseCacheAcrossSTSAuthorities(t *testing.T) {
+	first := newStub(t)
+	first.eiaResponse = map[string]any{
+		"access_token": "FIRST.EIA", "expires_in": 90, "scope": "manifold:proxy",
+	}
+	seed(t, first, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+	request := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`
+	if response, errOut, code := runCredentialProvider(t, request); code != 0 || errOut != "" || response.AccessToken != "FIRST.EIA" {
+		t.Fatalf("first authority = exit %d stderr %q %+v", code, errOut, response)
+	}
+
+	second := newStub(t)
+	second.eiaResponse = map[string]any{
+		"access_token": "SECOND.EIA", "expires_in": 90, "scope": "manifold:proxy",
+	}
+	t.Setenv("GASWORKS_STS_URL", second.srv.URL+"/")
+	t.Setenv("GASWORKS_OIDC_ISSUER", second.srv.URL+"/realms/g")
+	response, errOut, code := runCredentialProvider(t, request)
+	if code != 0 || errOut != "" || response.AccessToken != "SECOND.EIA" {
+		t.Fatalf("second authority = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if mints := len(second.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("second authority made %d mint requests, want 1", mints)
+	}
+	if logins := len(second.reqs("/sts/v0/login")); logins != 1 {
+		t.Fatalf("second authority made %d login requests, want an authority-local session", logins)
+	}
+}
+
+func TestCredentialProviderPrunesObsoleteCacheEntriesOnMint(t *testing.T) {
+	srv := newStub(t)
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	freezeNow(t, fixedNow)
+	requestKey := eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"})
+	expiredKey := eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:pool:acme"})
+	seed(t, srv, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			"org_a|manifold|manifold:proxy": map[string]any{
+				"eia": "LEGACY.EIA", "expires_at": fixedNow.Add(time.Hour).Unix(),
+			},
+			requestKey: map[string]any{
+				"eia": "EXPIRED.EIA", "expires_at": fixedNow.Unix(),
+			},
+			expiredKey: map[string]any{
+				"eia": "OTHER-EXPIRED.EIA", "expires_at": fixedNow.Add(-time.Second).Unix(),
+			},
+		},
+	})
+
+	response, errOut, code := runCredentialProvider(t, `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`)
+	if code != 0 || errOut != "" || response.AccessToken != "EIA.JWT" {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	cache := loadStore(t).EIACache
+	if len(cache) != 1 || cache[requestKey].EIA != "EIA.JWT" {
+		t.Fatalf("pruned cache = %+v, want only fresh requested credential", cache)
+	}
+}
+
+func TestCredentialProviderScopeOrderSharesCacheEntry(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+	first := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy","manifold:pool:acme"],
+		"interactive":false
+	}`
+	second := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:pool:acme","manifold:proxy"],
+		"interactive":false
+	}`
+	if response, _, code := runCredentialProvider(t, first); code != 0 || response.AccessToken == "" {
+		t.Fatalf("first request = exit %d %+v", code, response)
+	}
+	if response, _, code := runCredentialProvider(t, second); code != 0 || response.AccessToken == "" {
+		t.Fatalf("second request = exit %d %+v", code, response)
+	}
+	if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+		t.Fatalf("scope-order requests made %d mints", mints)
+	}
+}
+
+func TestCredentialProviderSharesCacheWithGetToken(t *testing.T) {
+	providerRequest := `{
+		"version":"gascity.dev/credential-provider/v1",
+		"audience":"manifold",
+		"required_scopes":["manifold:proxy"],
+		"interactive":false
+	}`
+	tests := []struct {
+		name  string
+		first func(*testing.T)
+		last  func(*testing.T)
+	}{
+		{
+			name: "getToken then provider",
+			first: func(t *testing.T) {
+				if _, errOut, code := capture(t, func() int {
+					return run([]string{"getToken", "manifold", "--scope", "manifold:proxy"})
+				}); code != 0 || errOut != "" {
+					t.Fatalf("getToken = exit %d stderr %q", code, errOut)
+				}
+			},
+			last: func(t *testing.T) {
+				if response, errOut, code := runCredentialProvider(t, providerRequest); code != 0 || errOut != "" || response.AccessToken != "EIA.JWT" {
+					t.Fatalf("provider = exit %d stderr %q %+v", code, errOut, response)
+				}
+			},
+		},
+		{
+			name: "provider then getToken",
+			first: func(t *testing.T) {
+				if response, errOut, code := runCredentialProvider(t, providerRequest); code != 0 || errOut != "" || response.AccessToken != "EIA.JWT" {
+					t.Fatalf("provider = exit %d stderr %q %+v", code, errOut, response)
+				}
+			},
+			last: func(t *testing.T) {
+				if out, errOut, code := capture(t, func() int {
+					return run([]string{"getToken", "manifold", "--scope", "manifold:proxy"})
+				}); code != 0 || errOut != "" || strings.TrimSpace(out) != "EIA.JWT" {
+					t.Fatalf("getToken = exit %d stdout %q stderr %q", code, out, errOut)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStub(t)
+			seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+
+			tt.first(t)
+			tt.last(t)
+
+			if mints := len(srv.reqs("/sts/v0/token")); mints != 1 {
+				t.Fatalf("cross-entry-point requests made %d mints", mints)
+			}
+			if entries := len(loadStore(t).EIACache); entries != 1 {
+				t.Fatalf("cache entries = %d, want 1", entries)
+			}
+		})
+	}
+}
+
+func TestCredentialProviderErrorsAreTypedAndSecretSafe(t *testing.T) {
+	tests := []struct {
+		name    string
+		creds   map[string]any
+		request string
+		code    string
+	}{
+		{
+			name: "unsupported version",
+			request: `{"version":"v0","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy"],"interactive":false}`,
+			code: "invalid_request",
+		},
+		{
+			name: "interactive invocation",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy"],"interactive":true}`,
+			code: "invalid_request",
+		},
+		{
+			name: "unknown field",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy"],"interactive":false,"token":"forged"}`,
+			code: "invalid_request",
+		},
+		{
+			name:    "trailing JSON",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"]}{}`,
+			code:    "invalid_request",
+		},
+		{
+			name:    "empty input",
+			request: "",
+			code:    "invalid_request",
+		},
+		{
+			name:    "truncated JSON",
+			request: `{"version":"gascity.dev/credential-provider/v1"`,
+			code:    "invalid_request",
+		},
+		{
+			name: "duplicate scope",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy","manifold:proxy"],"interactive":false}`,
+			code: "invalid_request",
+		},
+		{
+			name: "duplicate field",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"audience":"crucible","required_scopes":["manifold:proxy"],"interactive":false}`,
+			code: "invalid_request",
+		},
+		{
+			name: "case variant field",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"Audience":"crucible","required_scopes":["manifold:proxy"],"interactive":false}`,
+			code: "invalid_request",
+		},
+		{
+			name: "oversized request",
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"` +
+				strings.Repeat("a", credentialRequestMaxBytes) + `","required_scopes":["manifold:proxy"]}`,
+			code: "invalid_request",
+		},
+		{
+			name:  "login required",
+			creds: map[string]any{},
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy"],"interactive":false}`,
+			code: "interaction_required",
+		},
+		{
+			name:  "org access denied",
+			creds: map[string]any{"refresh_token": "RT", "id_token": validIDToken()},
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:proxy"],"org":"other","interactive":false}`,
+			code: "access_denied",
+		},
+		{
+			name:  "scope access denied",
+			creds: map[string]any{"refresh_token": "RT", "id_token": validIDToken()},
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold",` +
+				`"required_scopes":["manifold:admin"],"interactive":false}`,
+			code: "access_denied",
+		},
+		{
+			name:  "audience access denied",
+			creds: map[string]any{"refresh_token": "RT", "id_token": validIDToken()},
+			request: `{"version":"gascity.dev/credential-provider/v1","audience":"crucible",` +
+				`"required_scopes":["crucible:sandbox.read"],"interactive":false}`,
+			code: "access_denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStub(t)
+			seed(t, srv, tt.creds)
+
+			response, errOut, code := runCredentialProvider(t, tt.request)
+
+			if code == 0 {
+				t.Fatal("exit=0, want failure")
+			}
+			if errOut != "" {
+				t.Fatalf("stderr=%q, want structured stdout only", errOut)
+			}
+			if response.Version != credentialProviderVersion || response.Kind != "Error" || response.Code != tt.code {
+				t.Fatalf("error response = %+v", response)
+			}
+			if response.Message == "" || strings.Contains(response.Message, "forged") || response.AccessToken != "" {
+				t.Fatalf("error is not secret-safe: %+v", response)
+			}
+		})
+	}
+}
+
+func TestCredentialProviderRequestSizeBoundary(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+	request := `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`
+	atLimit := request + strings.Repeat(" ", credentialRequestMaxBytes-len(request))
+
+	if response, errOut, code := runCredentialProvider(t, atLimit); code != 0 || errOut != "" || response.Kind != "Credential" {
+		t.Fatalf("at-limit response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	contextCalls := len(srv.reqs("/sts/v0/context"))
+	loginCalls := len(srv.reqs("/sts/v0/login"))
+	tokenCalls := len(srv.reqs("/sts/v0/token"))
+	response, errOut, code := runCredentialProvider(t, atLimit+" ")
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != "invalid_request" {
+		t.Fatalf("over-limit response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	if len(srv.reqs("/sts/v0/context")) != contextCalls ||
+		len(srv.reqs("/sts/v0/login")) != loginCalls ||
+		len(srv.reqs("/sts/v0/token")) != tokenCalls {
+		t.Fatal("over-limit request reached an upstream endpoint")
+	}
+}
+
+func TestDecodeCredentialProviderRequestBoundaries(t *testing.T) {
+	decode := func(t *testing.T, request string) (credentialProviderRequest, error) {
+		t.Helper()
+		originalStdin := stdin
+		stdin = strings.NewReader(request)
+		defer func() { stdin = originalStdin }()
+		return decodeCredentialProviderRequest(nil)
+	}
+	encode := func(t *testing.T, request any) string {
+		t.Helper()
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		return string(encoded)
+	}
+
+	maxScopes := make([]string, credentialScopeMaxCount)
+	for index := range maxScopes {
+		maxScopes[index] = "scope:" + strings.Repeat("x", index+1)
+	}
+	maxScopes[len(maxScopes)-1] = strings.Repeat("s", credentialValueMaxBytes)
+	atLimits := credentialProviderRequest{
+		Version:        credentialProviderVersion,
+		Audience:       strings.Repeat("a", credentialValueMaxBytes),
+		RequiredScopes: maxScopes,
+		Org:            strings.Repeat("o", credentialValueMaxBytes),
+	}
+	decoded, err := decode(t, encode(t, atLimits))
+	if err != nil {
+		t.Fatalf("decode values at limits: %v", err)
+	}
+	if len(decoded.RequiredScopes) != credentialScopeMaxCount ||
+		len(decoded.Audience) != credentialValueMaxBytes ||
+		len(decoded.Org) != credentialValueMaxBytes {
+		t.Fatalf("decoded limits = audience %d org %d scopes %d", len(decoded.Audience), len(decoded.Org), len(decoded.RequiredScopes))
+	}
+
+	valid := func() map[string]any {
+		return map[string]any{
+			"version":         credentialProviderVersion,
+			"audience":        "manifold",
+			"required_scopes": []string{"manifold:proxy"},
+			"interactive":     false,
+		}
+	}
+	tests := []struct {
+		name    string
+		request string
+	}{
+		{name: "65 scopes", request: func() string {
+			request := valid()
+			scopes := make([]string, credentialScopeMaxCount+1)
+			for index := range scopes {
+				scopes[index] = "scope:" + strings.Repeat("x", index+1)
+			}
+			request["required_scopes"] = scopes
+			return encode(t, request)
+		}()},
+		{name: "513 byte audience", request: func() string {
+			request := valid()
+			request["audience"] = strings.Repeat("a", credentialValueMaxBytes+1)
+			return encode(t, request)
+		}()},
+		{name: "513 byte org", request: func() string {
+			request := valid()
+			request["org"] = strings.Repeat("o", credentialValueMaxBytes+1)
+			return encode(t, request)
+		}()},
+		{name: "513 byte scope", request: func() string {
+			request := valid()
+			request["required_scopes"] = []string{strings.Repeat("s", credentialValueMaxBytes+1)}
+			return encode(t, request)
+		}()},
+		{name: "missing scopes", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold"}`},
+		{name: "empty scopes", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":[]}`},
+		{name: "empty scope", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":[""]}`},
+		{name: "missing version", request: `{"audience":"manifold","required_scopes":["manifold:proxy"]}`},
+		{name: "empty audience", request: `{"version":"gascity.dev/credential-provider/v1","audience":"","required_scopes":["manifold:proxy"]}`},
+		{name: "whitespace audience", request: `{"version":"gascity.dev/credential-provider/v1","audience":"mani fold","required_scopes":["manifold:proxy"]}`},
+		{name: "whitespace org", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"org":"ac me"}`},
+		{name: "whitespace scope", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold: proxy"]}`},
+		{name: "number version", request: `{"version":1,"audience":"manifold","required_scopes":["manifold:proxy"]}`},
+		{name: "number audience", request: `{"version":"gascity.dev/credential-provider/v1","audience":1,"required_scopes":["manifold:proxy"]}`},
+		{name: "string scopes", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":"manifold:proxy"}`},
+		{name: "number scope", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":[1]}`},
+		{name: "number org", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"org":1}`},
+		{name: "string force refresh", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"force_refresh":"false"}`},
+		{name: "string interactive", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":"false"}`},
+		{name: "array top level", request: `[]`},
+		{name: "null top level", request: `null`},
+		{name: "string top level", request: `"request"`},
+		{name: "number top level", request: `1`},
+		{name: "boolean top level", request: `true`},
+		{name: "unicode whitespace", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["scope:a\u00a0scope:b"]}`},
+		{name: "control character", request: `{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["scope:a\u0000scope:b"]}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := decode(t, test.request); err == nil {
+				t.Fatal("decode succeeded, want invalid request")
+			}
+		})
+	}
+}
+
+func TestCredentialProviderRejectsScopeSeparatorsBeforeUpstreamCalls(t *testing.T) {
+	for _, scope := range []string{"scope:a\u00a0scope:b", "scope:a\x00scope:b"} {
+		t.Run(fmt.Sprintf("%q", scope), func(t *testing.T) {
+			srv := newStub(t)
+			seed(t, srv, map[string]any{"refresh_token": "RT", "id_token": validIDToken()})
+			request, err := json.Marshal(map[string]any{
+				"version":         credentialProviderVersion,
+				"audience":        "manifold",
+				"required_scopes": []string{scope},
+				"interactive":     false,
+			})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			response, errOut, code := runCredentialProvider(t, string(request))
+			if code == 0 || errOut != "" || response.Code != credentialErrorInvalid {
+				t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+			}
+			if got := len(srv.reqs("/sts/v0/context")) + len(srv.reqs("/sts/v0/login")) + len(srv.reqs("/sts/v0/token")); got != 0 {
+				t.Fatalf("invalid scope reached %d upstream endpoints", got)
+			}
+		})
+	}
+}
+
+func TestCredentialProviderRejectsSessionCompletedAfterLoginChanges(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{
+		"credential_generation": testCredentialGenerationA,
+		"refresh_token":         "RT-A",
+		"id_token":              validIDToken(),
+	})
+	srv.loginHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+		err := store.Update(func(data *store.Data) error {
+			data.CredentialGeneration = testCredentialGenerationB
+			data.RefreshToken = "RT-B"
+			data.IDToken = validIDToken()
+			data.Sessions = nil
+			data.EIACache = nil
+			return nil
+		})
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "test_login_switch_failed"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"session_token": "SESS-A", "session_id": "ses_a",
+			"org_id": form.Get("org"), "token_type": "DPoP", "expires_in": 28800,
+		})
+	}
+
+	response, errOut, code := runCredentialProvider(t,
+		`{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`)
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v, want secret-safe temporary failure", code, errOut, response)
+	}
+	persisted := loadStore(t)
+	if persisted.CredentialGeneration != testCredentialGenerationB || persisted.RefreshToken != "RT-B" {
+		t.Fatalf("persisted identity = generation %q refresh %q, want login B", persisted.CredentialGeneration, persisted.RefreshToken)
+	}
+	if len(persisted.Sessions) != 0 || len(persisted.EIACache) != 0 {
+		t.Fatalf("login A repopulated login B caches: sessions=%v eia_cache=%v", persisted.Sessions, persisted.EIACache)
+	}
+}
+
+func TestCredentialProviderRejectsEIACompletedAfterLogout(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, map[string]any{
+		"credential_generation": testCredentialGenerationA,
+		"refresh_token":         "RT-A",
+		"id_token":              validIDToken(),
+	})
+	srv.eiaHandler = func(w http.ResponseWriter, _ *http.Request, form url.Values) {
+		if err := store.Clear(); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "test_logout_failed"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"access_token": "EIA-A", "token_type": "DPoP",
+			"expires_in": 90, "scope": form.Get("scope"),
+		})
+	}
+
+	response, errOut, code := runCredentialProvider(t,
+		`{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`)
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v, want secret-safe temporary failure", code, errOut, response)
+	}
+	if _, err := store.Load(); err != nil {
+		t.Fatalf("load logged-out store: %v", err)
+	}
+	if _, err := os.Stat(store.CredsPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("credentials path after logout = %v, want missing", err)
+	}
+}
+
+func TestCredentialCacheKeysIncludeLoginGeneration(t *testing.T) {
+	sessionA := sessionCacheKey("https://works.gascity.com", "org-a", testCredentialGenerationA)
+	sessionB := sessionCacheKey("https://works.gascity.com", "org-a", testCredentialGenerationB)
+	if sessionA == sessionB {
+		t.Fatalf("session keys collide across login generations: %q", sessionA)
+	}
+
+	eiaA := eiaCacheKey("https://works.gascity.com", "org-a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"})
+	eiaB := eiaCacheKey("https://works.gascity.com", "org-a", "manifold", testCredentialGenerationB, []string{"manifold:proxy"})
+	if eiaA == eiaB {
+		t.Fatalf("EIA keys collide across login generations: %q", eiaA)
+	}
+}
+
+func TestCredentialProviderForceRefreshEvictsBeforeIdentityRefresh(t *testing.T) {
+	srv := newStub(t)
+	srv.refreshHandler = func(w http.ResponseWriter, _ *http.Request, _ url.Values) {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "temporarily_unavailable"})
+	}
+	cacheKey := eiaCacheKey(srv.srv.URL, "org_a", "manifold", testCredentialGenerationA, []string{"manifold:proxy"})
+	seed(t, srv, map[string]any{
+		"credential_generation": testCredentialGenerationA,
+		"refresh_token":         "RT-A",
+		"id_token":              expiredIDToken(),
+		"eia_cache": map[string]any{
+			cacheKey: map[string]any{"eia": "REJECTED-EIA", "expires_at": time.Now().Add(time.Hour).Unix()},
+		},
+	})
+
+	response, errOut, code := runCredentialProvider(t,
+		`{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"force_refresh":true,"interactive":false}`)
+	if code == 0 || errOut != "" || response.Kind != "Error" || response.Code != credentialErrorUnavailable {
+		t.Fatalf("response = exit %d stderr %q %+v, want early refresh failure", code, errOut, response)
+	}
+	if _, exists := loadStore(t).EIACache[cacheKey]; exists {
+		t.Fatal("force refresh left the rejected EIA reusable after identity refresh failed")
+	}
+}
+
+func TestCredentialProviderMigratesLegacyLoginGeneration(t *testing.T) {
+	srv := newStub(t)
+	seed(t, srv, nil)
+	writeCreds(t, map[string]any{
+		"refresh_token": "RT",
+		"id_token":      validIDToken(),
+		"eia_cache": map[string]any{
+			"legacy": map[string]any{"eia": "LEGACY-EIA", "expires_at": time.Now().Add(time.Hour).Unix()},
+		},
+	})
+
+	response, errOut, code := runCredentialProvider(t,
+		`{"version":"gascity.dev/credential-provider/v1","audience":"manifold","required_scopes":["manifold:proxy"],"interactive":false}`)
+	if code != 0 || errOut != "" || response.Kind != "Credential" {
+		t.Fatalf("response = exit %d stderr %q %+v", code, errOut, response)
+	}
+	persisted := loadStore(t)
+	if !validCredentialGeneration(persisted.CredentialGeneration) {
+		t.Fatalf("migrated generation = %q, want a valid durable generation", persisted.CredentialGeneration)
+	}
+	if _, exists := persisted.EIACache["legacy"]; exists {
+		t.Fatal("legacy cache survived generation migration")
+	}
+}

--- a/cmd/gasworks/gettoken.go
+++ b/cmd/gasworks/gettoken.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
+	"math"
+	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gascity/gasworks/internal/config"
 	"github.com/gascity/gasworks/internal/dpop"
@@ -17,10 +22,29 @@ import (
 
 // The three lifecycle freshness thresholds. (M11) They are DISTINCT — do not collapse them.
 const (
-	idTokenSkewSecs = 60 // refresh the id_token when it has <60s left
-	sessionSkewSecs = 30 // re-establish the STS session when it has <30s left
-	eiaSkewSecs     = 15 // re-mint the EIA when the cached one has <15s left
+	idTokenSkewSecs            = 60 // refresh the id_token when it has <60s left
+	sessionSkewSecs            = 30 // re-establish the STS session when it has <30s left
+	eiaSkewSecs                = 15 // re-mint the EIA when the cached one has <15s left
+	eiaCacheKeyVersion         = "gasworks.dev/eia-cache/v4"
+	humanCredentialKind        = "human"
+	sessionKeyVersion          = "gasworks.dev/sts-session/v3"
+	credentialGenerationPrefix = "g1:"
+	credentialGenerationBytes  = 16
 )
+
+var errCredentialGenerationChanged = errors.New("credential generation changed while minting")
+
+type humanCredentialSnapshot struct {
+	IDToken    string
+	Generation string
+}
+
+type mintResult struct {
+	AccessToken string
+	Audience    string
+	Scopes      []string
+	ExpiresAt   int64
+}
 
 func cmdGetToken(cfg config.Config, argv []string) error {
 	fs := flag.NewFlagSet("getToken", flag.ContinueOnError)
@@ -41,136 +65,333 @@ func cmdGetToken(cfg config.Config, argv []string) error {
 		return die("usage: gasworks getToken <product> [--org ...] [--scope ...] [--json] [--refresh]")
 	}
 
-	idToken, err := ensureIDToken(cfg)
+	scope := *scopeFlag
+	result, err := mintEIA(cfg, product, "", *orgFlag, scope, *refresh, false)
 	if err != nil {
 		return err
 	}
+	emit(result, *asJSON)
+	return nil
+}
+
+func mintEIA(
+	cfg config.Config,
+	product string,
+	audience string,
+	requestedOrg string,
+	scope string,
+	forceRefresh bool,
+	requireAllowedScopes bool,
+) (mintResult, error) {
+	if forceRefresh {
+		if err := store.Update(func(data *store.Data) error {
+			data.EIACache = nil
+			return nil
+		}); err != nil {
+			return mintResult{}, die("could not invalidate cached EIAs: %s", err)
+		}
+	}
+
+	credential, err := ensureHumanCredential(cfg, nil)
+	if err != nil {
+		return mintResult{}, err
+	}
+	idToken := credential.IDToken
+	generation := credential.Generation
 
 	ctx, err := sts.Context(cfg, idToken, true)
 	if err != nil {
-		return die("discovery failed: %s", err)
+		return mintResult{}, die("discovery failed: %s", err)
 	}
 
 	data, err := store.Load()
 	if err != nil {
-		return die("could not read credentials: %s", err)
+		return mintResult{}, die("could not read credentials: %s", err)
+	}
+	if data.CredentialGeneration != generation {
+		return mintResult{}, credentialChangedError()
 	}
 
-	org, err := pickOrg(ctx, *orgFlag, data)
+	org, err := pickOrg(ctx, requestedOrg, data)
 	if err != nil {
-		return err
+		return mintResult{}, err
 	}
 	orgCtx := orgByID(ctx, org)
 	if orgCtx == nil {
-		return die("you are not a member of org %s", org)
+		return mintResult{}, dieCredential(credentialErrorDenied, "you are not a member of org %s", org)
 	}
 
-	// The product must be a mintable product for this org regardless of --scope, so an
-	// explicit scope can't bypass this into a confusing raw STS 400 invalid_target.
-	prod, ok := orgCtx.Products[product]
+	var prod sts.Product
+	var ok bool
+	if product == "" {
+		product, prod, ok = productByAudience(orgCtx.Products, audience)
+	} else {
+		prod, ok = orgCtx.Products[product]
+	}
 	if !ok || len(prod.Scopes) == 0 {
-		return die("no mintable '%s' scope for org %s (entitled products: %s)",
-			product, orgCtx.Slug, productNames(orgCtx.Products))
+		requestedProduct := product
+		if requestedProduct == "" {
+			requestedProduct = audience
+		}
+		return mintResult{}, dieCredential(credentialErrorDenied, "no mintable '%s' scope for org %s (entitled products: %s)",
+			requestedProduct, orgCtx.Slug, productNames(orgCtx.Products))
 	}
-	scope := *scopeFlag
-	if scope == "" {
-		scope = strings.Join(prod.Scopes, " ") // default to the discovered scopes
+	canonicalAudience := prod.Audience
+	if canonicalAudience == "" {
+		canonicalAudience = product
+	}
+	if audience != "" && canonicalAudience != audience {
+		return mintResult{}, dieCredential(credentialErrorDenied, "no mintable '%s' scope for org %s (entitled products: %s)",
+			audience, orgCtx.Slug, productNames(orgCtx.Products))
 	}
 
-	cacheKey := org + "|" + product + "|" + scope
-	if !*refresh {
-		if cached, ok := data.EIACache[cacheKey]; ok && cached.ExpiresAt-now() > eiaSkewSecs {
-			emit(cached.EIA, scope, *asJSON)
-			return nil
+	if scope == "" {
+		scope = strings.Join(prod.Scopes, " ")
+	}
+	requestedScopes := strings.Fields(scope)
+	if requireAllowedScopes {
+		sort.Strings(requestedScopes)
+	}
+	if hasDuplicateScopes(requestedScopes) {
+		return mintResult{}, dieCredential(credentialErrorInvalid, "requested scopes contain duplicates")
+	}
+	if requireAllowedScopes && !scopeSubset(requestedScopes, prod.Scopes) {
+		return mintResult{}, dieCredential(credentialErrorDenied, "requested scopes are not mintable for '%s' in org %s", canonicalAudience, orgCtx.Slug)
+	}
+
+	cacheKey := eiaCacheKey(cfg.STSBase, org, canonicalAudience, generation, requestedScopes)
+	if !forceRefresh {
+		if cached, ok := data.EIACache[cacheKey]; ok &&
+			validOpaqueToken(cached.EIA) && credentialFreshAt(cached.ExpiresAt, now(), eiaSkewSecs) {
+			return mintResult{
+				AccessToken: cached.EIA,
+				Audience:    canonicalAudience,
+				Scopes:      requestedScopes,
+				ExpiresAt:   cached.ExpiresAt,
+			}, nil
 		}
 	}
 
-	sessionToken, key, err := ensureSession(cfg, data, org, idToken)
+	sessionToken, key, err := ensureSession(cfg, data, org, idToken, generation)
 	if err != nil {
-		return err
+		return mintResult{}, err
 	}
 
-	res, err := sts.Exchange(cfg, sessionToken, product, scope, key)
+	exchangeStartedAt := now()
+	res, err := sts.Exchange(cfg, sessionToken, canonicalAudience, strings.Join(requestedScopes, " "), key)
 	if err != nil {
 		var he *httpc.HTTPError
-		switch {
-		case errors.As(err, &he) && he.Status == 401:
+		if errors.As(err, &he) && he.Status == 401 {
 			// Session not resolvable — re-establish ONCE (fresh key) and retry exactly once.
-			sessionToken, key, err = newSession(cfg, org, idToken)
+			sessionToken, key, err = newSession(cfg, org, idToken, generation)
 			if err != nil {
-				return err
+				return mintResult{}, err
 			}
-			res, err = sts.Exchange(cfg, sessionToken, product, scope, key)
-			if err != nil {
-				return die("getToken failed: %s", err)
-			}
-		case errors.As(err, &he) && he.Status == 403:
-			return die("getToken denied: %s (%s)", he.OAuthError(), he)
-		default:
-			return die("getToken failed: %s", err)
+			exchangeStartedAt = now()
+			res, err = sts.Exchange(cfg, sessionToken, canonicalAudience, strings.Join(requestedScopes, " "), key)
 		}
 	}
+	if err != nil {
+		return mintResult{}, classifyExchangeError(err)
+	}
+	if !validOpaqueToken(res.AccessToken) {
+		return mintResult{}, die("getToken returned an invalid credential")
+	}
 
-	eia := res.AccessToken
+	grantedScopes := strings.Fields(res.Scope)
+	if len(grantedScopes) == 0 {
+		grantedScopes = requestedScopes
+	}
+	if !sameScopeSet(grantedScopes, requestedScopes) {
+		return mintResult{}, dieCredential(credentialErrorDenied, "getToken returned unexpected scopes")
+	}
+	expiresAt, ok := credentialExpiry(exchangeStartedAt, res.ExpiresIn)
+	if !ok || !credentialFreshAt(expiresAt, now(), 0) {
+		return mintResult{}, die("getToken returned an invalid credential expiry")
+	}
+	pruneAt := now()
 	if err := store.Update(func(d *store.Data) error {
+		if d.CredentialGeneration != generation {
+			return errCredentialGenerationChanged
+		}
 		if d.EIACache == nil {
 			d.EIACache = map[string]store.EIACacheEntry{}
 		}
-		d.EIACache[cacheKey] = store.EIACacheEntry{EIA: eia, ExpiresAt: now() + int64(res.ExpiresIn)}
+		pruneEIACache(d.EIACache, pruneAt)
+		d.EIACache[cacheKey] = store.EIACacheEntry{EIA: res.AccessToken, ExpiresAt: expiresAt}
 		return nil
 	}); err != nil {
-		return die("could not cache EIA: %s", err)
+		if errors.Is(err, errCredentialGenerationChanged) {
+			return mintResult{}, credentialChangedError()
+		}
+		return mintResult{}, die("could not cache EIA: %s", err)
 	}
 
-	grantedScope := res.Scope
-	if grantedScope == "" {
-		grantedScope = scope
+	return mintResult{
+		AccessToken: res.AccessToken,
+		Audience:    canonicalAudience,
+		Scopes:      grantedScopes,
+		ExpiresAt:   expiresAt,
+	}, nil
+}
+
+func classifyExchangeError(err error) *cmdError {
+	var httpErr *httpc.HTTPError
+	if errors.As(err, &httpErr) && httpErr.Status == http.StatusForbidden {
+		return dieCredential(credentialErrorDenied, "getToken denied: %s (%s)", httpErr.OAuthError(), httpErr)
 	}
-	emit(eia, grantedScope, *asJSON)
-	return nil
+	return dieCredential(credentialErrorUnavailable, "getToken is temporarily unavailable")
+}
+
+func credentialExpiry(startedAt int64, expiresIn int) (int64, bool) {
+	if expiresIn <= 0 {
+		return 0, false
+	}
+	lifetime := int64(expiresIn)
+	if startedAt > math.MaxInt64-lifetime {
+		return 0, false
+	}
+	expiresAt := startedAt + lifetime
+	if expiresAt <= startedAt || !credentialExpiryIsRFC3339(expiresAt) {
+		return 0, false
+	}
+	return expiresAt, true
+}
+
+func credentialFreshAt(expiresAt, instant, minimumRemaining int64) bool {
+	if minimumRemaining < 0 || !credentialExpiryIsRFC3339(expiresAt) ||
+		instant > math.MaxInt64-minimumRemaining {
+		return false
+	}
+	return expiresAt > instant+minimumRemaining
+}
+
+func credentialExpiryIsRFC3339(expiresAt int64) bool {
+	formatted := time.Unix(expiresAt, 0).UTC().Format(time.RFC3339)
+	parsed, err := time.Parse(time.RFC3339, formatted)
+	return err == nil && parsed.Unix() == expiresAt
+}
+
+func pruneEIACache(cache map[string]store.EIACacheEntry, instant int64) {
+	for key, entry := range cache {
+		if !strings.HasPrefix(key, eiaCacheKeyVersion+":") ||
+			!validOpaqueToken(entry.EIA) || !credentialFreshAt(entry.ExpiresAt, instant, 0) {
+			delete(cache, key)
+		}
+	}
 }
 
 // ensureIDToken returns a valid id_token, refreshing (and persisting the rotated refresh
 // token) if needed. (M10) The refresh rotation is persisted in its OWN locked write BEFORE any
 // later mint step, so a crash mid-getToken cannot lose the new refresh token.
 func ensureIDToken(cfg config.Config) (string, error) {
+	credential, err := ensureHumanCredential(cfg, nil)
+	return credential.IDToken, err
+}
+
+func ensureIDTokenBeforeRefreshTransaction(cfg config.Config, beforeTransaction func()) (string, error) {
+	credential, err := ensureHumanCredential(cfg, beforeTransaction)
+	return credential.IDToken, err
+}
+
+func ensureHumanCredential(cfg config.Config, beforeTransaction func()) (humanCredentialSnapshot, error) {
 	data, err := store.Load()
 	if err != nil {
-		return "", die("could not read credentials: %s", err)
+		return humanCredentialSnapshot{}, die("could not read credentials: %s", err)
 	}
-	if data.IDToken != "" && tokenExp(data.IDToken)-now() > idTokenSkewSecs {
-		return data.IDToken, nil
-	}
-	if data.RefreshToken == "" {
-		return "", die("not logged in — run `gasworks login`")
+	if data.IDToken != "" && tokenExp(data.IDToken)-now() > idTokenSkewSecs &&
+		validCredentialGeneration(data.CredentialGeneration) {
+		return humanCredentialSnapshot{IDToken: data.IDToken, Generation: data.CredentialGeneration}, nil
 	}
 
-	tok, err := oidc.Refresh(cfg, data.RefreshToken)
-	if err != nil {
-		var he *httpc.HTTPError
-		detail := err.Error()
-		if errors.As(err, &he) {
-			if oe := he.OAuthError(); oe != "" {
-				detail = oe
+	var credential humanCredentialSnapshot
+	if beforeTransaction != nil {
+		beforeTransaction()
+	}
+	err = store.Update(func(d *store.Data) error {
+		// Re-check under the cross-process store lock. Another process may have refreshed and
+		// persisted a rotated refresh token after the optimistic read above.
+		if d.IDToken != "" && tokenExp(d.IDToken)-now() > idTokenSkewSecs {
+			generation, generationErr := ensureCredentialGeneration(d)
+			if generationErr != nil {
+				return generationErr
 			}
+			credential = humanCredentialSnapshot{IDToken: d.IDToken, Generation: generation}
+			return nil
 		}
-		return "", die("session expired (%s) — run `gasworks login` again", detail)
-	}
+		if d.RefreshToken == "" {
+			return dieCredential(credentialErrorInteraction, "not logged in — run `gasworks login`")
+		}
+		generation, generationErr := ensureCredentialGeneration(d)
+		if generationErr != nil {
+			return generationErr
+		}
 
-	var idToken string
-	if err := store.Update(func(d *store.Data) error {
+		tok, refreshErr := oidc.Refresh(cfg, d.RefreshToken)
+		if refreshErr != nil {
+			return classifyRefreshError(refreshErr)
+		}
+		if tok.IDToken == "" {
+			return dieCredential(credentialErrorUnavailable, "identity provider returned no ID token")
+		}
 		if tok.RefreshToken != "" {
 			d.RefreshToken = tok.RefreshToken // Keycloak rotates — persist it
 		}
-		if tok.IDToken != "" {
-			d.IDToken = tok.IDToken
-		}
-		idToken = d.IDToken
+		d.IDToken = tok.IDToken
+		credential = humanCredentialSnapshot{IDToken: d.IDToken, Generation: generation}
 		return nil
-	}); err != nil {
-		return "", die("could not persist refreshed token: %s", err)
+	})
+	if err != nil {
+		var commandErr *cmdError
+		if errors.As(err, &commandErr) {
+			return humanCredentialSnapshot{}, commandErr
+		}
+		return humanCredentialSnapshot{}, die("could not persist refreshed token: %s", err)
 	}
-	return idToken, nil
+	return credential, nil
+}
+
+func newCredentialGeneration() (string, error) {
+	random := make([]byte, credentialGenerationBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return credentialGenerationPrefix + hex.EncodeToString(random), nil
+}
+
+func validCredentialGeneration(generation string) bool {
+	if len(generation) != len(credentialGenerationPrefix)+(credentialGenerationBytes*2) ||
+		!strings.HasPrefix(generation, credentialGenerationPrefix) {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(generation, credentialGenerationPrefix))
+	return err == nil
+}
+
+func ensureCredentialGeneration(data *store.Data) (string, error) {
+	if validCredentialGeneration(data.CredentialGeneration) {
+		return data.CredentialGeneration, nil
+	}
+	generation, err := newCredentialGeneration()
+	if err != nil {
+		return "", err
+	}
+	data.CredentialGeneration = generation
+	data.Sessions = nil
+	data.EIACache = nil
+	return generation, nil
+}
+
+func credentialChangedError() *cmdError {
+	return dieCredential(credentialErrorUnavailable, "login changed while minting a credential; retry the command")
+}
+
+func classifyRefreshError(err error) *cmdError {
+	var httpErr *httpc.HTTPError
+	if errors.As(err, &httpErr) && httpErr.OAuthError() == "invalid_grant" {
+		return dieCredential(credentialErrorInteraction, "session expired (invalid_grant) — run `gasworks login` again")
+	}
+	return dieCredential(credentialErrorUnavailable, "identity provider refresh is temporarily unavailable")
 }
 
 // pickOrg resolves the org to mint for: --org (id or slug) ▸ stored default_org ▸ the context
@@ -183,7 +404,7 @@ func pickOrg(ctx sts.ContextResolution, requested string, data *store.Data) (str
 				return o.OrgID, nil
 			}
 		}
-		return "", die("you are not a member of org '%s'. Your orgs: %s", requested, orgList(orgs))
+		return "", dieCredential(credentialErrorDenied, "you are not a member of org '%s'. Your orgs: %s", requested, orgList(orgs))
 	}
 	if data.DefaultOrg != "" && orgByIDIn(orgs, data.DefaultOrg) {
 		return data.DefaultOrg, nil
@@ -195,14 +416,14 @@ func pickOrg(ctx sts.ContextResolution, requested string, data *store.Data) (str
 		return orgs[0].OrgID, nil
 	}
 	if len(orgs) == 0 {
-		return "", die("no orgs for this account — run `gasworks whoami` to check, or ask an admin to add you to an org")
+		return "", dieCredential(credentialErrorDenied, "no orgs for this account — run `gasworks whoami` to check, or ask an admin to add you to an org")
 	}
-	return "", die("you belong to multiple orgs — pass --org. Your orgs: %s", orgList(orgs))
+	return "", dieCredential(credentialErrorInvalid, "you belong to multiple orgs — pass --org. Your orgs: %s", orgList(orgs))
 }
 
 // newSession generates a FRESH DPoP key, establishes a new STS session, and persists it
 // (locked). A fresh key per new session matches the server's per-session jkt-pin.
-func newSession(cfg config.Config, org, idToken string) (string, *dpop.Key, error) {
+func newSession(cfg config.Config, org, idToken, generation string) (string, *dpop.Key, error) {
 	key, err := dpop.NewKey()
 	if err != nil {
 		return "", nil, die("could not generate a session key: %s", err)
@@ -211,7 +432,7 @@ func newSession(cfg config.Config, org, idToken string) (string, *dpop.Key, erro
 	if err != nil {
 		var he *httpc.HTTPError
 		if errors.As(err, &he) && he.Status == 403 {
-			return "", nil, die("not a member of org %s (%s)", org, he.OAuthError())
+			return "", nil, dieCredential(credentialErrorDenied, "not a member of org %s (%s)", org, he.OAuthError())
 		}
 		return "", nil, die("login to org %s failed: %s", org, err)
 	}
@@ -220,16 +441,22 @@ func newSession(cfg config.Config, org, idToken string) (string, *dpop.Key, erro
 		return "", nil, die("could not serialize the session key: %s", err)
 	}
 	if err := store.Update(func(d *store.Data) error {
+		if d.CredentialGeneration != generation {
+			return errCredentialGenerationChanged
+		}
 		if d.Sessions == nil {
 			d.Sessions = map[string]store.Session{}
 		}
-		d.Sessions[org] = store.Session{
+		d.Sessions[sessionCacheKey(cfg.STSBase, org, generation)] = store.Session{
 			SessionToken: sess.SessionToken,
 			DPoPPEM:      pem,
 			ExpiresAt:    now() + int64(sess.ExpiresIn),
 		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, errCredentialGenerationChanged) {
+			return "", nil, credentialChangedError()
+		}
 		return "", nil, die("could not save the session: %s", err)
 	}
 	return sess.SessionToken, key, nil
@@ -237,15 +464,30 @@ func newSession(cfg config.Config, org, idToken string) (string, *dpop.Key, erro
 
 // ensureSession reuses the stored per-org session when it has >30s left (loading its DPoP key
 // from PEM), otherwise establishes a fresh one.
-func ensureSession(cfg config.Config, data *store.Data, org, idToken string) (string, *dpop.Key, error) {
-	if sess, ok := data.Sessions[org]; ok && sess.ExpiresAt-now() > sessionSkewSecs {
+func ensureSession(cfg config.Config, data *store.Data, org, idToken, generation string) (string, *dpop.Key, error) {
+	if sess, ok := data.Sessions[sessionCacheKey(cfg.STSBase, org, generation)]; ok && sess.ExpiresAt-now() > sessionSkewSecs {
 		key, err := dpop.FromPEM(sess.DPoPPEM)
 		if err == nil {
 			return sess.SessionToken, key, nil
 		}
 		// A corrupt stored key falls through to a fresh session rather than crashing.
 	}
-	return newSession(cfg, org, idToken)
+	return newSession(cfg, org, idToken, generation)
+}
+
+func sessionCacheKey(stsAuthority, org, generation string) string {
+	payload, _ := json.Marshal(struct {
+		CredentialKind string `json:"credential_kind"`
+		Generation     string `json:"generation"`
+		STSAuthority   string `json:"sts_authority"`
+		Org            string `json:"org"`
+	}{
+		CredentialKind: humanCredentialKind,
+		Generation:     generation,
+		STSAuthority:   strings.TrimRight(stsAuthority, "/"),
+		Org:            org,
+	})
+	return sessionKeyVersion + ":" + string(payload)
 }
 
 // hoistPositional pulls the single bareword product out of argv (in any position, like
@@ -286,19 +528,32 @@ func hoistPositional(argv []string) (product string, rest []string) {
 	return product, rest
 }
 
-func emit(eia, scope string, asJSON bool) {
+func emit(result mintResult, asJSON bool) {
 	if asJSON {
+		remaining := result.ExpiresAt - now()
+		if remaining < 0 {
+			remaining = 0
+		}
 		env := struct {
 			AccessToken string `json:"access_token"`
 			TokenType   string `json:"token_type"`
 			ExpiresIn   int    `json:"expires_in"`
+			ExpiresAt   string `json:"expires_at"`
+			Audience    string `json:"audience"`
 			Scope       string `json:"scope"`
-		}{eia, "DPoP", 90, scope}
+		}{
+			AccessToken: result.AccessToken,
+			TokenType:   "Bearer",
+			ExpiresIn:   int(remaining),
+			ExpiresAt:   time.Unix(result.ExpiresAt, 0).UTC().Format(time.RFC3339),
+			Audience:    result.Audience,
+			Scope:       strings.Join(result.Scopes, " "),
+		}
 		b, _ := json.Marshal(env)
 		stdoutLine(string(b))
 		return
 	}
-	stdoutLine(eia) // raw EIA, pipeable
+	stdoutLine(result.AccessToken) // raw EIA, pipeable
 }
 
 func orgByID(ctx sts.ContextResolution, id string) *sts.OrgContext {
@@ -329,4 +584,80 @@ func productNames(products map[string]sts.Product) string {
 	}
 	sort.Strings(names)
 	return strings.Join(names, ", ")
+}
+
+func productByAudience(products map[string]sts.Product, audience string) (string, sts.Product, bool) {
+	var productName string
+	var product sts.Product
+	for name, candidate := range products {
+		candidateAudience := candidate.Audience
+		if candidateAudience == "" {
+			candidateAudience = name
+		}
+		if candidateAudience != audience {
+			continue
+		}
+		if productName != "" {
+			return "", sts.Product{}, false
+		}
+		productName = name
+		product = candidate
+	}
+	return productName, product, productName != ""
+}
+
+func scopeSubset(requested, allowed []string) bool {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, scope := range allowed {
+		allowedSet[scope] = struct{}{}
+	}
+	for _, scope := range requested {
+		if _, ok := allowedSet[scope]; !ok {
+			return false
+		}
+	}
+	return len(requested) > 0
+}
+
+func sameScopeSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	return scopeSubset(left, right) && scopeSubset(right, left)
+}
+
+func hasDuplicateScopes(scopes []string) bool {
+	seen := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		if _, duplicate := seen[scope]; duplicate {
+			return true
+		}
+		seen[scope] = struct{}{}
+	}
+	return false
+}
+
+func validOpaqueToken(token string) bool {
+	return token != "" && token == strings.TrimSpace(token) && !strings.ContainsAny(token, " \t\r\n")
+}
+
+func eiaCacheKey(stsAuthority, org, audience, generation string, scopes []string) string {
+	canonicalScopes := append([]string(nil), scopes...)
+	sort.Strings(canonicalScopes)
+	payload, _ := json.Marshal(struct {
+		CredentialKind string   `json:"credential_kind"`
+		Generation     string   `json:"generation"`
+		STSAuthority   string   `json:"sts_authority"`
+		Org            string   `json:"org"`
+		Audience       string   `json:"audience"`
+		Scopes         []string `json:"scopes"`
+	}{
+		CredentialKind: humanCredentialKind,
+		Generation:     generation,
+		STSAuthority:   strings.TrimRight(stsAuthority, "/"),
+		Org:            org,
+		Audience:       audience,
+		Scopes:         canonicalScopes,
+	})
+	return eiaCacheKeyVersion + ":" + string(payload)
 }

--- a/cmd/gasworks/io.go
+++ b/cmd/gasworks/io.go
@@ -10,6 +10,7 @@ import (
 // streams) so tests can capture them deterministically without spawning a subprocess. Tokens
 // and machine-readable data go to stdout; prompts and errors go to stderr.
 var (
+	stdin  io.Reader = os.Stdin
 	stdout io.Writer = os.Stdout
 	stderr io.Writer = os.Stderr
 )

--- a/cmd/gasworks/login.go
+++ b/cmd/gasworks/login.go
@@ -38,6 +38,9 @@ func cmdLogin(cfg config.Config, argv []string) error {
 	if idt == "" {
 		return die("login returned no id_token (is the 'openid' scope enabled on the client?)")
 	}
+	if !validOpaqueToken(tok.RefreshToken) {
+		return die("login returned no refresh_token (is the 'offline_access' scope enabled on the client?)")
+	}
 
 	// (M9/M3) Advisory sanity checks over the DECODED-BUT-UNVERIFIED id_token. These are
 	// NOT a trust boundary — the CLI never verifies the JWT signature; the STS is the real
@@ -62,15 +65,16 @@ func cmdLogin(cfg config.Config, argv []string) error {
 	if exp := jwtutil.Exp(claims); exp != 0 && exp <= time.Now().Unix() {
 		return die("the id_token is already expired (exp=%d) — check the client clock", exp)
 	}
+	generation, err := newCredentialGeneration()
+	if err != nil {
+		return die("could not create a login generation: %s", err)
+	}
 
 	if err := store.Update(func(d *store.Data) error {
 		d.IDToken = idt
-		if tok.RefreshToken != "" {
-			d.RefreshToken = tok.RefreshToken
-		}
-		if *org != "" {
-			d.DefaultOrg = *org
-		}
+		d.CredentialGeneration = generation
+		d.RefreshToken = tok.RefreshToken
+		d.DefaultOrg = *org
 		// A fresh login invalidates any prior STS sessions / cached EIAs.
 		d.Sessions = nil
 		d.EIACache = nil

--- a/cmd/gasworks/main.go
+++ b/cmd/gasworks/main.go
@@ -1,5 +1,5 @@
 // Command gasworks is the SSO login + getToken (EIA) CLI for Gas City. It wires the
-// internal client packages (oidc, sts, store, dpop, jwtutil, config) into four subcommands.
+// internal client packages (oidc, sts, store, dpop, jwtutil, config) into its subcommands.
 //
 // The token lifecycle has three layers, each cached with its own DISTINCT TTL threshold:
 //
@@ -44,6 +44,8 @@ func run(argv []string) int {
 		err = cmdLogin(cfg, rest)
 	case "getToken", "get-token":
 		err = cmdGetToken(cfg, rest)
+	case "credential-provider":
+		return cmdCredentialProvider(cfg, rest)
 	case "whoami":
 		err = cmdWhoami(cfg, rest)
 	case "logout":
@@ -70,11 +72,12 @@ func run(argv []string) int {
 	return 0
 }
 
-// cmdError carries a user-facing message and exit code. It mirrors the Python _die() contract:
-// the message is printed to stderr prefixed with "gasworks:" and the process exits non-zero.
+// cmdError carries a user-facing message and exit code. Interactive commands print its message
+// to stderr; the credential-provider boundary maps its category to a fixed JSON error instead.
 type cmdError struct {
-	msg  string
-	code int
+	msg               string
+	code              int
+	credentialErrCode string
 }
 
 func (e *cmdError) Error() string { return e.msg }
@@ -85,7 +88,11 @@ func die(format string, a ...any) *cmdError {
 	return &cmdError{msg: fmt.Sprintf(format, a...), code: 1}
 }
 
-func now() int64 { return time.Now().Unix() }
+func dieCredential(code, format string, a ...any) *cmdError {
+	return &cmdError{msg: fmt.Sprintf(format, a...), code: 1, credentialErrCode: code}
+}
+
+var now = func() int64 { return time.Now().Unix() }
 
 // eprintf prints to stderr with a trailing newline (prompts + errors go to stderr; tokens and
 // data go to stdout).
@@ -133,6 +140,7 @@ func printUsage() {
 Usage:
   gasworks login [--device|--browser] [--org <id|slug>]
   gasworks getToken <product> [--org <id|slug>] [--scope "<space-sep>"] [--json] [--refresh]
+  gasworks credential-provider
   gasworks whoami
   gasworks logout
   gasworks version`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gascity/gasworks
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gastownhall/gascity v1.1.1-0.20260625212128-87de14874a96

--- a/internal/store/lock_windows.go
+++ b/internal/store/lock_windows.go
@@ -2,12 +2,59 @@
 
 package store
 
-// lock is a best-effort no-op on Windows, matching the Python store which falls back to a
-// best-effort msvcrt lock and tolerates failure. The atomic rename in Save still gives a
-// single-writer-consistent file; cross-process RMW races are accepted on Windows.
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const lockfileExclusiveLock = 0x00000002
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	lockFileExProc   = kernel32.NewProc("LockFileEx")
+	unlockFileExProc = kernel32.NewProc("UnlockFileEx")
+)
+
+// lock takes an exclusive, process-scoped lock on one byte of the lock file. Windows releases
+// the lock when the handle closes, including after process termination, so a crashed CLI cannot
+// strand a stale lock. LockFileEx blocks until the current refresh transaction completes.
 func lock() (func(), error) {
 	if _, err := ensureDir(); err != nil {
 		return nil, err
 	}
-	return func() {}, nil
+	file, err := os.OpenFile(lockPath(), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	overlapped := &syscall.Overlapped{}
+	result, _, callErr := lockFileExProc.Call(
+		file.Fd(),
+		lockfileExclusiveLock,
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+	if result == 0 {
+		_ = file.Close()
+		return nil, windowsCallError(callErr)
+	}
+	return func() {
+		_, _, _ = unlockFileExProc.Call(
+			file.Fd(),
+			0,
+			1,
+			0,
+			uintptr(unsafe.Pointer(overlapped)),
+		)
+		_ = file.Close()
+	}, nil
+}
+
+func windowsCallError(err error) error {
+	if errno, ok := err.(syscall.Errno); ok && errno == 0 {
+		return syscall.EINVAL
+	}
+	return err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,14 +32,16 @@ type EIACacheEntry struct {
 	ExpiresAt int64  `json:"expires_at"`
 }
 
-// Data is the on-disk credential document. Maps are omitempty so a fresh, never-written
-// store roundtrips to {} rather than {"sessions":null,...}.
+// Data is the on-disk credential document. CredentialGeneration fences session and EIA
+// writes across login/logout changes. Maps are omitempty so a fresh, never-written store
+// roundtrips to {} rather than {"sessions":null,...}.
 type Data struct {
-	IDToken      string                   `json:"id_token,omitempty"`
-	RefreshToken string                   `json:"refresh_token,omitempty"`
-	DefaultOrg   string                   `json:"default_org,omitempty"`
-	Sessions     map[string]Session       `json:"sessions,omitempty"`
-	EIACache     map[string]EIACacheEntry `json:"eia_cache,omitempty"`
+	IDToken              string                   `json:"id_token,omitempty"`
+	RefreshToken         string                   `json:"refresh_token,omitempty"`
+	CredentialGeneration string                   `json:"credential_generation,omitempty"`
+	DefaultOrg           string                   `json:"default_org,omitempty"`
+	Sessions             map[string]Session       `json:"sessions,omitempty"`
+	EIACache             map[string]EIACacheEntry `json:"eia_cache,omitempty"`
 }
 
 // ConfigDir resolves the gasworks config directory:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -18,7 +18,8 @@ func setConfigDir(t *testing.T, sub string) string {
 func TestSaveLoadRoundtrip(t *testing.T) {
 	setConfigDir(t, "cfg")
 	want := &Data{
-		RefreshToken: "rt",
+		RefreshToken:         "rt",
+		CredentialGeneration: "g1:00000000000000000000000000000001",
 		Sessions: map[string]Session{
 			"org_a": {SessionToken: "t", DPoPPEM: "...", ExpiresAt: 42},
 		},

--- a/internal/sts/sts.go
+++ b/internal/sts/sts.go
@@ -22,9 +22,6 @@ const grantTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
 // expires_in.
 const defaultSessionExpiresIn = 28800
 
-// defaultEIAExpiresIn is the fallback EIA lifetime (90s) when the server omits expires_in.
-const defaultEIAExpiresIn = 90
-
 // Product is a per-org mintable product: the EIA audience and the scopes the caller may
 // request for it.
 type Product struct {
@@ -130,9 +127,6 @@ func Exchange(cfg config.Config, sessionToken, audience, scope string, key *dpop
 	var eia EIA
 	if err := remarshal(body, &eia); err != nil {
 		return EIA{}, fmt.Errorf("exchange: %w", err)
-	}
-	if eia.ExpiresIn == 0 {
-		eia.ExpiresIn = defaultEIAExpiresIn
 	}
 	return eia, nil
 }


### PR DESCRIPTION
## Summary

- add the stable `gasworks credential-provider` v1 JSON protocol for noninteractive STS credential minting
- serialize refresh-token rotation and fence in-flight credential writes across login/logout identity changes
- return truthful Bearer metadata and absolute expiry while keeping malformed/upstream failures secret-safe
- update the Go toolchain to 1.26.5 and add Windows locking/build coverage

## Testing

- `GOTOOLCHAIN=go1.26.5 go test -mod=vendor ./... -race -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet -mod=vendor ./...`
- `GOTOOLCHAIN=go1.26.5 go build -mod=vendor ./...`
- `GOTOOLCHAIN=go1.26.5 go mod verify`
- `GOTOOLCHAIN=go1.26.5 go mod vendor` (no drift)
- Windows cross-compilation tests
- `govulncheck ./...`
- `actionlint`
- `goreleaser build --snapshot --clean`
- `gofmt -l .`
- `git diff --check`